### PR TITLE
Wrap a function's return type in a block

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
@@ -273,8 +273,10 @@ class KotlinInputAstVisitor(val builder: OpsBuilder) : KtTreeVisitorVoid() {
       if (type != null) {
         builder.block(ZERO) {
           builder.token(":")
-          builder.space()
-          type.accept(this)
+          builder.breakOp(Doc.FillMode.INDEPENDENT, " ", expressionBreakIndent)
+          builder.block(expressionBreakIndent) {
+            type.accept(this)
+          }
         }
       }
       builder.space()

--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -540,9 +540,29 @@ class FormatterKtTest {
   @Test
   fun `multi line function without a block body`() = assertFormatted(
       """
-      |fun longFunctionNoBlock(): Int =
+      |fun longFunctionNoBlock():
+      |    Int =
+      |    1234567 + 1234567
+      |fun shortFun(): Int =
       |    1234567 + 1234567
       |""".trimMargin(), 25)
+
+  @Test
+  fun `return type doesn't fit in one line`() = assertFormatted(
+  """
+      |interface X {
+      |  fun f(arg1: Arg1Type, arg2: Arg2Type):
+      |      Map<String, Map<String, Double>>? {
+      |    //
+      |  }
+      |
+      |  fun functionWithGenericReturnType(
+      |      arg1: Arg1Type, arg2: Arg2Type
+      |  ): Map<String, Map<String, Double>>? {
+      |    //
+      |  }
+      |}
+      |""".trimMargin(), 50)
 
   @Test
   fun `list of superclasses`() = assertFormatted(


### PR DESCRIPTION
Summary:
See new tests.

The handling of `longFunctionNoBlock` isn't ideal:

```
fun longFunctionNoBlock():
    Int =
    1234567 + 1234567

```

but I think it's a move in the right direction.

Differential Revision: D19245784

