### PR TITLE
Unbreak GitHub CI

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -14,6 +14,7 @@
     <properties>
         <kotlin.version>1.3.50</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
+        <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>             
         <main.class>com.facebook.ktfmt.MainKt</main.class>
     </properties>
 


### PR DESCRIPTION
This fixes the build error "Cannot inline bytecode built with JVM target 1.8 into bytecode that is being built with JVM target 1.6. Please specify proper '-jvm-target' option"