### PR TITLE
Honor original spacing after links

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/kdoc/KDocFormatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/kdoc/KDocFormatter.kt
@@ -81,7 +81,6 @@ object KDocFormatter {
         KDocTokens.CODE_BLOCK_TEXT -> tokens.add(Token(CODE, tokenText))
         KDocTokens.MARKDOWN_INLINE_LINK, KDocTokens.MARKDOWN_LINK -> {
           tokens.add(Token(LITERAL, tokenText))
-          tokens.add(Token(WHITESPACE, " "))
         }
         KDocTokens.TEXT -> {
           if (tokenText.isBlank()) {
@@ -89,6 +88,11 @@ object KDocFormatter {
           } else if (tokenText == "```") {
             tokens.add(Token(CODE_BLOCK_MARKER, tokenText))
           } else {
+            if ((previousType == KDocTokens.MARKDOWN_INLINE_LINK ||
+                previousType == KDocTokens.MARKDOWN_LINK) && tokenText[0].isWhitespace()) {
+              tokens.add(Token(WHITESPACE, " "))
+            }
+
             val words = tokenText.trim().split(" +".toRegex())
             var first = true
             for (word in words) {
@@ -110,10 +114,11 @@ object KDocFormatter {
           }
         }
         WHITE_SPACE -> {
-          if (previousType === KDocTokens.TAG_NAME || previousType === KDocTokens.MARKDOWN_LINK) {
+          if (previousType === KDocTokens.TAG_NAME ||
+              previousType === KDocTokens.MARKDOWN_LINK ||
+              previousType === KDocTokens.MARKDOWN_INLINE_LINK) {
             tokens.add(Token(WHITESPACE, " "))
-          } else if (previousType ==
-              KDocTokens.LEADING_ASTERISK ||
+          } else if (previousType == KDocTokens.LEADING_ASTERISK ||
               tokenText.count { it == '\n' } >= 2) {
             tokens.add(Token(BLANK_LINE, ""))
           }

--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -2105,20 +2105,35 @@ class FormatterKtTest {
   fun `handle KDoc with links one after another`() =
       assertFormatted(
           """
-      |/** Here are some links [AnotherClass] [AnotherClass2] */
+      |/** Here are some links [AnotherClass] [AnotherClass2]. */
       |class MyClass {}
       |""".trimMargin())
 
   @Test
-  fun `add spaces after links in Kdoc`() {
+  fun `add spaces between links in KDoc`() {
     val code =
         """
-      |/** Here are some links [AnotherClass][AnotherClass2]hello */
+      |/** Here are some links [AnotherClass][AnotherClass2] */
       |class MyClass {}
       |""".trimMargin()
     val expected =
         """
-      |/** Here are some links [AnotherClass] [AnotherClass2] hello */
+      |/** Here are some links [AnotherClass] [AnotherClass2] */
+      |class MyClass {}
+      |""".trimMargin()
+    assertThatFormatting(code).isEqualTo(expected)
+  }
+
+  @Test
+  fun `collapse spaces after links in KDoc`() {
+    val code =
+        """
+      |/** Here are some links [Class1],[Class2]   [Class3]. hello */
+      |class MyClass {}
+      |""".trimMargin()
+    val expected =
+        """
+      |/** Here are some links [Class1], [Class2] [Class3]. hello */
       |class MyClass {}
       |""".trimMargin()
     assertThatFormatting(code).isEqualTo(expected)


### PR DESCRIPTION
There are legitimate reasons to want or not want whitespace after links in KDoc comments, so try to preserve the original intent but still clean up excessive spacing.

Fixes issue #22.
