### PR TITLE
Update com.google.truth to 1.0 in the pom.xml

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -158,7 +158,7 @@
         <dependency>
             <groupId>com.google.truth</groupId>
             <artifactId>truth</artifactId>
-            <version>0.45</version>
+            <version>1.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Summary: I changed the buck files but didn't change the pom.xml, so CI broke in github

Differential Revision: D20251270

