### PR TITLE
Use google-java-format 1.8 from Maven Central

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # test against latest update of each major Java version, as well as specific updates of LTS versions:
-        java: [ 1.8, 11, 13 ]
+        java: [ 11, 13 ]
     name: build on Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v1

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 **Note** that `ktfmt` still has some rough edges which we're constantly working on fixing.
 
+The minimum supported runtime version is JDK 11, released September 2018.
+
 ## Demo
 
 |Before Formatting| Formatted by `ktfmt`| 
@@ -61,11 +63,9 @@ However, we do offer an escape-hatch for projects that absolutely cannot make th
 
 ### Setup
 
-* Make sure the `vendor/google-java/format` submodule is populated. Either clone with submodules (`git pull --recurse-submodules https://github.com/facebookincubator/ktfmt.git`) or populate the submodule after cloning (`git submodule update --init`)
 * Open `pom.xml` in IntelliJ. Choose "Open as a Project"
 * The IntelliJ project will unfortunately be broken on import. To fix,
     * Turn off ErrorProne by removing the compiler parameters in IntelliJ at the bottom of "Settings -> Build, Execution, Deployment -> Compiler -> Java Compiler" (see https://github.com/google/google-java-format/issues/417)
-    * Right click on "vendor/google-java-format/pom.xml" and choose "Add maven project"    
 
 ### Development
 
@@ -73,7 +73,6 @@ However, we do offer an escape-hatch for projects that absolutely cannot make th
 
 ### Building on the Command Line
 
-* Make sure the `vendor/google-java/format` submodule is populated. Either clone with submodules (`git pull --recurse-submodules https://github.com/facebookincubator/ktfmt.git`) or populate the submodule after cloning (`git submodule update --init`)
 * Run `mvn install`
 * Run `java -jar core/target/ktfmt-<VERSION>-jar-with-dependencies.jar`
 

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -156,7 +156,7 @@
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
-            <version>1.8-SNAPSHOT</version>
+            <version>1.8</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
@@ -204,17 +204,22 @@
                         </executions>
                     </plugin>
 
-                    <!-- KDoc / Javadoc JAR -->
+                    <!-- Javadoc JAR -->
+                    <!-- Dokka, Kotlin's javadoc, doesn't work on JDK 10+, so we're creating an empty javadoc jar instead. -->
+                    <!-- (https://github.com/Kotlin/dokka/issues/294) -->
                     <plugin>
-                        <groupId>org.jetbrains.dokka</groupId>
-                        <artifactId>dokka-maven-plugin</artifactId>
-                        <version>${dokka.version}</version>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
                         <executions>
                             <execution>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>javadocJar</goal>
+                                    <goal>jar</goal>
                                 </goals>
+                                <configuration>
+                                    <classifier>javadoc</classifier>
+                                    <classesDirectory>${project.basedir}/non/existing/dir</classesDirectory>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,6 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>vendor/google-java-format/core</module>
         <module>core</module>
   </modules>
 </project>


### PR DESCRIPTION
instead of vendoring the source.

GJF 1.8 requires JDK 11+, so `ktfmt` will also now require JDK 11+.

This unlocks https://github.com/facebookincubator/ktfmt/issues/30