### PR TITLE
feat: add support for suspended types

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
@@ -173,6 +173,7 @@ class KotlinInputAstVisitor(
     if (addParenthesis) {
       builder.token("(")
     }
+    nullableType.modifierList?.accept(this)
     innerType?.accept(this)
     if (addParenthesis) {
       builder.token(")")

--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -2259,6 +2259,19 @@ class FormatterKtTest {
       |""".trimMargin())
 
   @Test
+  fun `handle suspended types`() =
+      assertFormatted(
+          """
+      |private val reader: suspend (Key) -> Output?
+      |
+      |private val delete: (suspend (Key) -> Unit)? = null
+      |
+      |inline fun <R> foo(noinline block: suspend () -> R): suspend () -> R
+      |
+      |inline fun <R> bar(noinline block: (suspend () -> R)?): (suspend () -> R)?
+      |""".trimMargin())
+
+  @Test
   fun `handle simple enum classes`() =
       assertFormatted(
           """


### PR DESCRIPTION
Adds support for suspended nullable return types. It successfully handles formatting of the file in #32.

Resolves #32. 
