### PR TITLE
Add static function to represent dropbox style option in formatting options

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/Formatter.kt
@@ -70,7 +70,14 @@ class FormattingOptions(
      *     1)
      * ```
      */
-    val continuationIndent: Int = 4)
+    val continuationIndent: Int = 4) {
+  companion object {
+    /**
+     * Represents dropbox style formatting.
+     */
+    fun dropboxStyle(): FormattingOptions = FormattingOptions(blockIndent = 4, continuationIndent = 4)
+  }
+}
 
 /**
  * format formats the Kotlin code given in 'code' and returns it as a string. This method is

--- a/core/src/main/java/com/facebook/ktfmt/ParsedArgs.kt
+++ b/core/src/main/java/com/facebook/ktfmt/ParsedArgs.kt
@@ -34,6 +34,6 @@ fun parseOptions(err: PrintStream, args: Array<String>): ParsedArgs {
   }
   return ParsedArgs(
       fileNames,
-      if (isDropboxStyle) FormattingOptions(blockIndent = 4, continuationIndent = 4)
+      if (isDropboxStyle) FormattingOptions.dropboxStyle()
       else FormattingOptions())
 }


### PR DESCRIPTION
Add a public api to represent dropbox style formatting options in order to avoid the duplication of formatting logic from consumers of ktfmt such as in: https://github.com/diffplug/spotless/pull/642