### PR TITLE
Use kotlin-compiler-embeddable instead of kotlin-compiler

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -153,8 +153,14 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
-            <artifactId>kotlin-compiler</artifactId>
+            <artifactId>kotlin-compiler-embeddable</artifactId>
             <version>${kotlin.version}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/net.java.dev.jna/jna -->
+        <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+            <version>4.2.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.googlejavaformat</groupId>

--- a/core/src/main/java/com/facebook/ktfmt/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/Formatter.kt
@@ -26,10 +26,10 @@ import com.google.googlejavaformat.DocBuilder
 import com.google.googlejavaformat.Newlines
 import com.google.googlejavaformat.OpsBuilder
 import com.google.googlejavaformat.java.JavaOutput
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.openapi.util.text.StringUtilRt
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtilRt
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.psiUtil.endOffset
 import org.jetbrains.kotlin.psi.psiUtil.startOffset

--- a/core/src/main/java/com/facebook/ktfmt/KotlinInput.kt
+++ b/core/src/main/java/com/facebook/ktfmt/KotlinInput.kt
@@ -29,11 +29,11 @@ import com.google.googlejavaformat.Input
 import com.google.googlejavaformat.Newlines
 import com.google.googlejavaformat.java.FormatterException
 import com.google.googlejavaformat.java.JavaOutput
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.psi.PsiComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
-import com.intellij.psi.impl.source.tree.LeafPsiElement
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.impl.source.tree.LeafPsiElement
 import java.util.regex.Pattern
 import org.jetbrains.kotlin.lexer.KtToken
 import org.jetbrains.kotlin.lexer.KtTokens

--- a/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
@@ -25,9 +25,9 @@ import com.google.googlejavaformat.Indent
 import com.google.googlejavaformat.Indent.Const.ZERO
 import com.google.googlejavaformat.OpsBuilder
 import com.google.googlejavaformat.Output
-import com.intellij.psi.PsiComment
-import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiWhiteSpace
+import org.jetbrains.kotlin.com.intellij.psi.PsiComment
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import java.util.ArrayDeque
 import java.util.Deque
 import java.util.LinkedHashSet

--- a/core/src/main/java/com/facebook/ktfmt/Parser.kt
+++ b/core/src/main/java/com/facebook/ktfmt/Parser.kt
@@ -16,12 +16,12 @@
 
 package com.facebook.ktfmt
 
-import com.intellij.openapi.util.Disposer
-import com.intellij.openapi.util.text.LineColumn
-import com.intellij.openapi.util.text.StringUtil
-import com.intellij.psi.PsiErrorElement
-import com.intellij.psi.PsiManager
-import com.intellij.testFramework.LightVirtualFile
+import org.jetbrains.kotlin.com.intellij.openapi.util.Disposer
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.LineColumn
+import org.jetbrains.kotlin.com.intellij.openapi.util.text.StringUtil
+import org.jetbrains.kotlin.com.intellij.psi.PsiErrorElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiManager
+import org.jetbrains.kotlin.com.intellij.testFramework.LightVirtualFile
 import org.jetbrains.kotlin.cli.common.CLIConfigurationKeys
 import org.jetbrains.kotlin.cli.common.messages.MessageRenderer.PLAIN_RELATIVE_PATHS
 import org.jetbrains.kotlin.cli.common.messages.PrintingMessageCollector

--- a/core/src/main/java/com/facebook/ktfmt/PrintAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/PrintAstVisitor.kt
@@ -16,7 +16,7 @@
 
 package com.facebook.ktfmt
 
-import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.psi.KtTreeVisitorVoid
 
 class PrintAstVisitor : KtTreeVisitorVoid() {

--- a/core/src/main/java/com/facebook/ktfmt/RedundantElementRemover.kt
+++ b/core/src/main/java/com/facebook/ktfmt/RedundantElementRemover.kt
@@ -16,7 +16,7 @@
 
 package com.facebook.ktfmt
 
-import com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocImpl
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocLink
 import org.jetbrains.kotlin.kdoc.psi.impl.KDocName

--- a/core/src/main/java/com/facebook/ktfmt/kdoc/KDocFormatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/kdoc/KDocFormatter.kt
@@ -35,7 +35,7 @@ import com.facebook.ktfmt.kdoc.Token.Type.TABLE_CLOSE_TAG
 import com.facebook.ktfmt.kdoc.Token.Type.TABLE_OPEN_TAG
 import com.facebook.ktfmt.kdoc.Token.Type.TAG
 import com.facebook.ktfmt.kdoc.Token.Type.WHITESPACE
-import com.intellij.psi.tree.IElementType
+import org.jetbrains.kotlin.com.intellij.psi.tree.IElementType
 import java.util.regex.Pattern.compile
 import org.jetbrains.kotlin.kdoc.lexer.KDocLexer
 import org.jetbrains.kotlin.kdoc.lexer.KDocTokens


### PR DESCRIPTION
Summary:
The two libraries are identical, except kotlin-compiler-embeddable shadows all IntelliJ classes under the `org.jetbrains.kotlin` namespace.

Using kotlin-compiler causes ODR violations when using `ktfmt` inside IntelliJ in e.g., a plugin.

Differential Revision: D23018190

