### PR TITLE
chore: bump `intellij.version` for new EAP

### DIFF
--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     java
 }
 
-val ktfmtVersion = "0.19"
+val ktfmtVersion = "0.18"
 
 group = "com.facebook"
 version = "1.1-SNAPSHOT.$ktfmtVersion"
@@ -41,9 +41,11 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2020.3"
+    version = "LATEST-EAP-SNAPSHOT"
 }
-tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
-    changeNotes("""
-      First version.""")
+
+tasks {
+    patchPluginXml {
+        sinceBuild("203")
+    }
 }

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = "2020.2"
+    version = "2020.3"
 }
 tasks.getByName<org.jetbrains.intellij.tasks.PatchPluginXmlTask>("patchPluginXml") {
     changeNotes("""


### PR DESCRIPTION
### Description

Fixes #61 

Solves issue where not compatible with latest EAP

![image](https://user-images.githubusercontent.com/12074633/94601841-10fd0500-0262-11eb-8e59-15f740bdbc6c.png)

![image](https://user-images.githubusercontent.com/12074633/94638100-395b2280-02a7-11eb-9b43-43f6e73ec5c1.png)
