### PR TITLE
Break before each call parameter if they don't all fit in one line

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitor.kt
@@ -730,12 +730,19 @@ class KotlinInputAstVisitor(
   ) {
     builder.block(ZERO) {
       callee?.accept(this)
-      val argumentsSize = argumentList?.arguments?.size ?: 0
+      val arguments = argumentList?.arguments
+      val argumentsSize = arguments?.size ?: 0
       builder.block(argumentsIndent) { typeArgumentList?.accept(this) }
       builder.block(argumentsIndent) {
         builder.guessToken("(")
         if (argumentsSize > 0) {
-          builder.block(ZERO) { argumentList?.accept(this) }
+          argumentList?.accept(this)
+          val first = arguments?.firstOrNull()
+          if (argumentsSize != 1 ||
+              first?.isNamed() != false ||
+              first.getArgumentExpression() !is KtLambdaExpression) {
+            builder.breakOp(Doc.FillMode.UNIFIED, "", expressionBreakNegativeIndent)
+          }
         }
         builder.guessToken(")")
       }
@@ -759,7 +766,7 @@ class KotlinInputAstVisitor(
     } else {
       // Break before args.
       builder.breakOp(Doc.FillMode.UNIFIED, "", ZERO)
-      emitParameterLikeList(list.arguments, list.trailingComma != null, wrapInBlock = true)
+      emitParameterLikeList(list.arguments, list.trailingComma != null, wrapInBlock = false)
     }
   }
 

--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -74,15 +74,23 @@ class FormatterKtTest {
       |  computeBreaks(
       |      javaOutput.commentsHelper,
       |      maxWidth,
-      |      Doc.State(+0, 0))
+      |      Doc.State(+0, 0)
+      |  )
       |  computeBreaks(
-      |      output.commentsHelper, maxWidth, State(0))
+      |      output.commentsHelper,
+      |      maxWidth,
+      |      State(0)
+      |  )
       |  doc.computeBreaks(
       |      javaOutput.commentsHelper,
       |      maxWidth,
-      |      Doc.State(+0, 0))
+      |      Doc.State(+0, 0)
+      |  )
       |  doc.computeBreaks(
-      |      output.commentsHelper, maxWidth, State(0))
+      |      output.commentsHelper,
+      |      maxWidth,
+      |      State(0)
+      |  )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -164,7 +172,8 @@ class FormatterKtTest {
         |          .add(1)
         |          .add(1)
         |          .add(1)
-        |          .build())
+        |          .build()
+        |  )
         |
         |  ImmutableList.newBuilder()
         |      .add(1)
@@ -263,7 +272,8 @@ class FormatterKtTest {
       |          (1 + 2) +
       |          function(
       |              value7,
-      |              value8) +
+      |              value8
+      |          ) +
       |          value9
       |}
       |""".trimMargin(),
@@ -474,13 +484,15 @@ class FormatterKtTest {
       |  // Break after `longerThanFour(` before it's longer than 4 chars
       |  longerThanFour(
       |          something.something
-      |              .happens())
+      |              .happens()
+      |      )
       |      .thenReturn(result)
       |
       |  // Similarly to above, when part of qualified expression.
       |  foo.longerThanFour(
       |          something.something
-      |              .happens())
+      |              .happens()
+      |      )
       |      .thenReturn(result)
       |
       |  // Keep 'super' attached to the method name
@@ -589,7 +601,9 @@ class FormatterKtTest {
       |class C {
       |  fun method() {
       |    Foo.FooBar(
-      |            param1, param2)
+      |            param1,
+      |            param2
+      |        )
       |        .apply {
       |          //
       |          foo
@@ -974,7 +988,8 @@ class FormatterKtTest {
       |  foo(
       |      123456789012345678901234567890,
       |      123456789012345678901234567890,
-      |      123456789012345678901234567890)
+      |      123456789012345678901234567890
+      |  )
       |}
       |""".trimMargin())
 
@@ -988,7 +1003,8 @@ class FormatterKtTest {
       |  foo(
       |      123456789012345678901234567890,
       |      b = 23456789012345678901234567890,
-      |      c = 3456789012345678901234567890)
+      |      c = 3456789012345678901234567890
+      |  )
       |}
       |""".trimMargin())
 
@@ -1003,7 +1019,8 @@ class FormatterKtTest {
       |              // Printing
       |              print()
       |            },
-      |        duration = duration)
+      |        duration = duration
+      |    )
       |""".trimMargin())
 
   @Test
@@ -1027,7 +1044,8 @@ class FormatterKtTest {
       |        typeConstraintList =
       |            property.typeConstraintList,
       |        delegate = property.delegate,
-      |        initializer = property.initializer)
+      |        initializer = property.initializer
+      |    )
       |  }
       |}
       |""".trimMargin(),
@@ -1041,7 +1059,8 @@ class FormatterKtTest {
       |  setListener(
       |      fun(number: Int) {
       |        println(number)
-      |      })
+      |      }
+      |  )
       |}
       |""".trimMargin())
 
@@ -1053,7 +1072,8 @@ class FormatterKtTest {
       |  setListener(
       |      fun View.() {
       |        println(this)
-      |      })
+      |      }
+      |  )
       |}
       |""".trimMargin())
 
@@ -1170,7 +1190,13 @@ class FormatterKtTest {
       |          ACTION_UP -> Toast.makeText(it.view.context, "Up!", Toast.LENGTH_SHORT).show()
       |          ACTION_DOWN ->
       |              Toast.makeText(
-      |                      it.view.context, "Down!", Toast.LENGTH_SHORT, blablabla, blablabl, blabla)
+      |                      it.view.context,
+      |                      "Down!",
+      |                      Toast.LENGTH_SHORT,
+      |                      blablabla,
+      |                      blablabl,
+      |                      blabla
+      |                  )
       |                  .show()
       |        }
       |      }
@@ -1495,7 +1521,8 @@ class FormatterKtTest {
       |      if (b) {
       |        val a = 1 + 1
       |        2 * a
-      |      } else 2)
+      |      } else 2
+      |  )
       |  return if (b) 1 else 2
       |}
       |""".trimMargin())
@@ -1721,7 +1748,8 @@ class FormatterKtTest {
       |      age,
       |      title,
       |      offspring,
-      |      offspring)
+      |      offspring
+      |  )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -2069,10 +2097,12 @@ class FormatterKtTest {
       |  Stuff()
       |      .doIt(
       |          Foo.doIt()
-      |              .doThat())
+      |              .doThat()
+      |      )
       |      .doIt(
       |          Foo.doIt()
-      |              .doThat())
+      |              .doThat()
+      |      )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -2187,12 +2217,40 @@ class FormatterKtTest {
       |---------------------------
       |fun f() {
       |  fooDdoIt(
-      |      foo1, foo2, foo3)
+      |      foo1,
+      |      foo2,
+      |      foo3
+      |  )
       |  foo.doIt(
-      |      foo1, foo2, foo3)
+      |      foo1,
+      |      foo2,
+      |      foo3
+      |  )
       |  foo.doIt(
-      |          foo1, foo2, foo3)
+      |          foo1,
+      |          foo2,
+      |          foo3
+      |      )
       |      .doThat()
+      |}
+      |""".trimMargin(),
+          deduceMaxWidth = true)
+
+  // TODO: fix this.
+  @Test
+  fun `chained calls that don't fit in one line`() =
+      assertFormatted(
+          """
+      |---------------------------
+      |fun f() {
+      |  foo(
+      |          println("a"),
+      |          println("b")
+      |      )
+      |      .bar(
+      |          println("b"),
+      |          println("b")
+      |      )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -2230,7 +2288,8 @@ class FormatterKtTest {
       |      functor = {
       |        val a = it
       |        a + a
-      |      })
+      |      }
+      |  )
       |}
       |""".trimMargin())
 
@@ -2518,7 +2577,8 @@ class FormatterKtTest {
       |      lambdaArgument = {
       |        step1()
       |        step2()
-      |      }) { it.doIt() }
+      |      }
+      |  ) { it.doIt() }
       |}
       |""".trimMargin())
 
@@ -2682,23 +2742,28 @@ class FormatterKtTest {
       |) {
       |  println(
       |      something is
-      |          List<String>)
+      |          List<String>
+      |  )
       |  doIt(
       |      something as
-      |          List<String>)
+      |          List<String>
+      |  )
       |  println(
       |      something is
       |          PairList<
       |              String,
-      |              Int>)
+      |              Int>
+      |  )
       |  doIt(
       |      something as
       |          PairList<
       |              String,
-      |              Int>)
+      |              Int>
+      |  )
       |  println(
       |      a is Int &&
-      |          b is String)
+      |          b is String
+      |  )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -3853,7 +3918,9 @@ class FormatterKtTest {
       |  )
       |
       |  foo<Int>(
-      |      "asdf", "asdf")
+      |      "asdf",
+      |      "asdf"
+      |  )
       |
       |  foo<
       |      Int,

--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -1612,7 +1612,8 @@ class FormatterKtTest {
       |---------------------------
       |data class Foo {
       |  constructor(
-      |      val number: Int = 0)
+      |      val number: Int = 0
+      |  )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -1696,7 +1697,8 @@ class FormatterKtTest {
       |      val name: String,
       |      val age: Int,
       |      val title: String,
-      |      val offspring: List<Foo>)
+      |      val offspring: List<Foo>
+      |  )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
@@ -1723,6 +1725,22 @@ class FormatterKtTest {
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)
+
+  @Test
+  fun `secondary constructor with param list that fits in one line, with delegate`() =
+      assertFormatted(
+          """
+      |class C {
+      |  constructor(
+      |      context: Context?,
+      |      attrs: AttributeSet?,
+      |      defStyleAttr: Int,
+      |      defStyleRes: Int
+      |  ) : super(context, attrs, defStyleAttr, defStyleRes) {
+      |    init(attrs)
+      |  }
+      |}
+      |""".trimMargin())
 
   @Test
   fun `handle calling super constructor in secondary constructor`() =
@@ -3771,7 +3789,9 @@ class FormatterKtTest {
       |
       |class Foo {
       |  constructor(
-      |      a: Int, b: Int)
+      |      a: Int,
+      |      b: Int
+      |  )
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)

--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -1208,13 +1208,15 @@ class FormatterKtTest {
       |--------------------------------------------------
       |interface X {
       |  fun f(
-      |      arg1: Arg1Type, arg2: Arg2Type
+      |      arg1: Arg1Type,
+      |      arg2: Arg2Type
       |  ): Map<String, Map<String, Double>>? {
       |    //
       |  }
       |
       |  fun functionWithGenericReturnType(
-      |      arg1: Arg1Type, arg2: Arg2Type
+      |      arg1: Arg1Type,
+      |      arg2: Arg2Type
       |  ): Map<String, Map<String, Double>>? {
       |    //
       |  }
@@ -1583,7 +1585,12 @@ class FormatterKtTest {
       |class Foo5
       |    @Inject
       |    private constructor(
-      |        number: Int, number2: Int, number3: Int, number4: Int, number5: Int, number6: Int
+      |        number: Int,
+      |        number2: Int,
+      |        number3: Int,
+      |        number4: Int,
+      |        number5: Int,
+      |        number6: Int
       |    ) {}
       |""".trimMargin())
 
@@ -1593,7 +1600,8 @@ class FormatterKtTest {
           """
       |-------------------------
       |data class Foo(
-      |    val number: Int = 0)
+      |    val number: Int = 0
+      |)
       |""".trimMargin(),
           deduceMaxWidth = true)
 
@@ -1627,7 +1635,11 @@ class FormatterKtTest {
       assertFormatted(
           """
       |data class Foo(
-      |    val number: Int, val name: String, val age: Int, val title: String, val offspring2: List<Foo>
+      |    val number: Int,
+      |    val name: String,
+      |    val age: Int,
+      |    val title: String,
+      |    val offspring2: List<Foo>
       |) {}
       |""".trimMargin())
 
@@ -1637,7 +1649,11 @@ class FormatterKtTest {
           """
       |data class Foo
       |    constructor(
-      |        val name: String, val age: Int, val title: String, val offspring: List<Foo>, val foo: String
+      |        val name: String,
+      |        val age: Int,
+      |        val title: String,
+      |        val offspring: List<Foo>,
+      |        val foo: String
       |    ) {}
       |""".trimMargin())
 
@@ -3705,7 +3721,9 @@ class FormatterKtTest {
       |)
       |
       |class Foo(
-      |    a: Int, b: Int)
+      |    a: Int,
+      |    b: Int
+      |)
       |""".trimMargin(),
           deduceMaxWidth = true)
 
@@ -3727,7 +3745,9 @@ class FormatterKtTest {
       |
       |class Foo
       |    constructor(
-      |        a: Int, b: Int)
+      |        a: Int,
+      |        b: Int
+      |    )
       |""".trimMargin(),
           deduceMaxWidth = true)
 
@@ -3775,7 +3795,8 @@ class FormatterKtTest {
       |) {}
       |
       |fun foo(
-      |    a: Int, b: Int
+      |    a: Int,
+      |    b: Int
       |) {}
       |
       |fun foo(


### PR DESCRIPTION
Summary:
This is an RFC diff.

See modified tests.

Call chains are formatted like this:
```
Foo.FooBar(
        param1,
        param2
    )
    .apply {
      //
      foo
    }
```
and not something like
```
Foo.FooBar(
        param1,
        param2
    ).apply {
      //
      foo
    }
```

Differential Revision: D25179272

