### PR TITLE
Add support to all versions above 2020.1.4, including

### DIFF
--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -30,8 +30,8 @@ repositories {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 dependencies {
@@ -39,13 +39,18 @@ dependencies {
     implementation("com.google.googlejavaformat", "google-java-format", "1.8")
 }
 
-// See https://github.com/JetBrains/gradle-intellij-plugin/
+/**
+ * Minimum compatible version.
+ *
+ * `intellij.version` should match `sinceBuild(value)`
+ */
 intellij {
-    version = "LATEST-EAP-SNAPSHOT"
+    version = "2020.1.4"
 }
 
 tasks {
     patchPluginXml {
-        sinceBuild("203")
+        sinceBuild("201")
+        untilBuild("")
     }
 }

--- a/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/CodeStyleManagerDecorator.java
+++ b/ktfmt_idea_plugin/src/main/java/com/facebook/ktfmt/intellij/CodeStyleManagerDecorator.java
@@ -231,9 +231,4 @@ class CodeStyleManagerDecorator extends CodeStyleManager
     }
     return offset;
   }
-
-  @Override
-  public void scheduleReformatWhenSettingsComputed(PsiFile file) {
-    delegate.scheduleReformatWhenSettingsComputed(file);
-  }
 }


### PR DESCRIPTION
Now Android Studio 4.1.1 is compatible too which is the latest stable version. It fixes https://github.com/facebookincubator/ktfmt/issues/61

To get it working with Android Studio 4.1.1, I need to downgrade from Java 11 to Java 8.

The plugin can be installed in AS 4.1.1, can be enabled, and change its settings, but it doesn't work when you try to reformat (it does nothing). Meanwhile, the same plugin installed in the latest AS Canary or in IntelliJ works.