### PR TITLE
Use ktfmt 0.19 in IDEA plugin

### DIFF
--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -19,7 +19,7 @@ plugins {
     java
 }
 
-val ktfmtVersion = "0.18"
+val ktfmtVersion = "0.19"
 
 group = "com.facebook"
 version = "1.1-SNAPSHOT.$ktfmtVersion"


### PR DESCRIPTION
It looks like `bump_version.sh` will update the plugin from version 0.20 on, but this needs to be done manually for 0.19.
