### PR TITLE
Keep so-called "scoping functions" on same line as assignment

### DIFF
--- a/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/FormatterKtTest.kt
@@ -1167,6 +1167,11 @@ class FormatterKtTest {
       |    doItTwice()
       |  }
       |}
+      |
+      |fun foo() = {
+      |  doItOnce()
+      |  doItTwice()
+      |}
       |""".trimMargin())
 
   @Test
@@ -4010,6 +4015,29 @@ class FormatterKtTest {
       |  } catch (e: Error,) {
       |    //
       |  }
+      |}
+      |""".trimMargin(),
+          deduceMaxWidth = true)
+
+  @Test
+  fun `assignment of a scoping function`() =
+      assertFormatted(
+          """
+      |----------------------------
+      |val foo = coroutineScope {
+      |  foo()
+      |  //
+      |}
+      |
+      |fun foo() = coroutineScope {
+      |  foo()
+      |  //
+      |}
+      |
+      |fun longName() =
+      |    coroutineScope {
+      |  foo()
+      |  //
       |}
       |""".trimMargin(),
           deduceMaxWidth = true)

--- a/core/src/test/java/com/facebook/ktfmt/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/GoogleStyleFormatterKtTest.kt
@@ -710,4 +710,19 @@ class GoogleStyleFormatterKtTest {
       |""".trimMargin(),
           formattingOptions = GOOGLE_FORMAT,
           deduceMaxWidth = true)
+
+  // TODO: fix indentation of foo()
+  @Test
+  fun `assignment of a scoping function`() =
+      assertFormatted(
+          """
+      |----------------------------
+      |fun longName() =
+      |  coroutineScope {
+      |  foo()
+      |  //
+      |}
+      |""".trimMargin(),
+          formattingOptions = GOOGLE_FORMAT,
+          deduceMaxWidth = true)
 }


### PR DESCRIPTION
Summary:
See examples in tests.

Note that the Google style version has a problem, because it has equal continuation and block indents. One solution would be to emit conditional blocks, after we create them :) (https://github.com/google/google-java-format/issues/556)

Reviewed By: hick209

Differential Revision: D25738228

