### PR TITLE
fix: version compatibility

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,4 +1,4 @@
-name: Build ktfmt JetBrains plugin
+name: Build JetBrains plugin
 
 on:
   push:

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -31,4 +31,4 @@ jobs:
     - name: Verify plugin
       run: |
         cd ktfmt_idea_plugin
-        ./ktfmt_idea_plugin/gradlew verifyPlugin
+        ./gradlew verifyPlugin

--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,0 +1,34 @@
+name: Build ktfmt JetBrains plugin
+
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # test against latest update of each major Java version, as well as specific updates of LTS versions:
+        java: [ 11, 13 ]
+    name: Build plugin on Java ${{ matrix.java }}
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: recursive
+    - name: Set up JDK ${{ matrix.java }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: ${{ matrix.java }}
+    - name: Build plugin
+      run: |
+        cd ktfmt_idea_plugin
+        ./gradlew buildPlugin
+    - name: Verify plugin
+      run: |
+        cd ktfmt_idea_plugin
+        ./ktfmt_idea_plugin/gradlew verifyPlugin

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -41,8 +41,8 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    // Default value: the version with which to build (and run; unless alternativeIdePath is specified)
-    version = "LATEST-EAP-SNAPSHOT"
+    // Version with which to build (and run; unless alternativeIdePath is specified)
+    version = "2020.3"
     // See https://github.com/JetBrains/gradle-intellij-plugin#building-properties
     updateSinceUntilBuild = false
     // To run on a different IDE, uncomment and specify a path.

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -41,8 +41,10 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    // Version with which to build (and run; unless alternativeIdePath is specified)
-    version = "2020.3"
+    // Default value: the version with which to build (and run; unless alternativeIdePath is specified)
+    version = "LATEST-EAP-SNAPSHOT"
+    // See https://github.com/JetBrains/gradle-intellij-plugin#building-properties
+    updateSinceUntilBuild = false
     // To run on a different IDE, uncomment and specify a path.
     // alternativeIdePath = "/Applications/Android Studio.app"
 }


### PR DESCRIPTION
### Description

Uses the default (`LATEST-EAP-SNAPSHOT`) for `version`, since we probably want to build on latest.

Also changes `updateSinceUntilBuild` to `false` from it's default `true`. I believe this is good to address issues where the plugin isn't available for EAP and other JetBrains IDEs.

See https://github.com/JetBrains/gradle-intellij-plugin#building-properties.

Similar to Prettier's plugin: https://github.com/JetBrains/intellij-plugins/blob/master/prettierJS/build.gradle.kts

---

Here is a demo of one of my plugins ([release pull request](https://github.com/jef/forest-night-jetbrains/pull/24)) for verification:

![image](https://user-images.githubusercontent.com/12074633/109342084-56d1ef80-7839-11eb-82bd-4521f6cd0917.png)

vs not having it:

![image](https://user-images.githubusercontent.com/12074633/109342112-63564800-7839-11eb-8d35-8af320cb49af.png)
