### PR TITLE
Add Spotless (GoogleJavaFormat) to IDEA plugin

### DIFF
--- a/.github/workflows/plugin.yml
+++ b/.github/workflows/plugin.yml
@@ -1,0 +1,28 @@
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # test against latest update of each major Java version, as well as specific updates of LTS versions:
+        java: [ 11, 13 ]
+    name: Build plugin on Java ${{ matrix.java }}
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          submodules: recursive
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java }}
+      - name: Build
+        run: |
+          cd ktfmt_idea_plugin
+          ./gradlew build

--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -17,6 +17,7 @@
 plugins {
     id("org.jetbrains.intellij") version "0.4.21"
     java
+    id("com.diffplug.spotless") version "5.10.2"
 }
 
 val ktfmtVersion = "0.20"
@@ -50,5 +51,11 @@ intellij {
 tasks {
     patchPluginXml {
         sinceBuild("201")
+    }
+}
+
+spotless {
+    java {
+        googleJavaFormat()
     }
 }


### PR DESCRIPTION
To ensure the IDEA plugin code is formatted correctly, Spotless will check it every time a push or PR.

I tweaked the plugin workflow created by @jef to just use `./gradlew build` which depends on the task `spotlessJavaCheck`, so it will check if the plugin code compiles, tests pass, and if the code is correctly formatted.

To automatically format the code, run `./gradlew spotlessJavaApply`.