### PR TITLE
[ktfmt] Don't use guessToken("(") when emitting parenthesis in call elements

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitorBase.kt
+++ b/core/src/main/java/com/facebook/ktfmt/KotlinInputAstVisitorBase.kt
@@ -745,7 +745,9 @@ open class KotlinInputAstVisitorBase(
       val arguments = argumentList?.arguments.orEmpty()
       builder.block(argumentsIndent) { typeArgumentList?.accept(this) }
       builder.block(argumentsIndent) {
-        builder.guessToken("(")
+        if (argumentList != null) {
+          builder.token("(")
+        }
         if (arguments.isNotEmpty()) {
           if (isGoogleStyle) {
             argumentList?.accept(this)
@@ -759,7 +761,9 @@ open class KotlinInputAstVisitorBase(
             builder.block(ZERO) { argumentList?.accept(this) }
           }
         }
-        builder.guessToken(")")
+        if (argumentList != null) {
+          builder.token(")")
+        }
       }
       if (lambdaArguments.isNotEmpty()) {
         builder.space()


### PR DESCRIPTION
As reported in https://github.com/facebookincubator/ktfmt/issues/186, this causes the call element to accidentally eat up the parenthesis of the _next_ expression.