### PR TITLE
Fix GitHub Action to publish to maven central

### DIFF
--- a/.github/workflows/publish_to_ossrh.yaml
+++ b/.github/workflows/publish_to_ossrh.yaml
@@ -12,6 +12,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
       - id: install-secret-key
         name: Install gpg secret key
         run: |


### PR DESCRIPTION
by correctly setting up settings.xml before callin mvn deploy