### PR TITLE
Support `expect enum class` without a body.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1299,7 +1299,9 @@ class KotlinInputAstVisitor(
       }
       val body = classOrObject.body
       if (classOrObject.hasModifier(KtTokens.ENUM_KEYWORD)) {
-        visitEnumBody(classOrObject as KtClass)
+        if (body != null || !classOrObject.hasModifier(KtTokens.EXPECT_KEYWORD)) {
+          visitEnumBody(classOrObject as KtClass)
+        }
       } else if (body != null) {
         visitBlockBody(body, true)
       }

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1299,9 +1299,7 @@ class KotlinInputAstVisitor(
       }
       val body = classOrObject.body
       if (classOrObject.hasModifier(KtTokens.ENUM_KEYWORD)) {
-        if (body != null) {
-          visitEnumBody(classOrObject as KtClass)
-        }
+        visitEnumBody(classOrObject as KtClass)
       } else if (body != null) {
         visitBlockBody(body, true)
       }
@@ -1314,6 +1312,9 @@ class KotlinInputAstVisitor(
   /** Example `{ RED, GREEN; fun foo() { ... } }` for an enum class */
   private fun visitEnumBody(enumClass: KtClass) {
     val body = enumClass.body
+    if (body == null) {
+      return
+    }
     builder.token("{", Doc.Token.RealOrImaginary.REAL, blockIndent, Optional.of(blockIndent))
     builder.open(ZERO)
     builder.block(blockIndent) {

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1299,7 +1299,7 @@ class KotlinInputAstVisitor(
       }
       val body = classOrObject.body
       if (classOrObject.hasModifier(KtTokens.ENUM_KEYWORD)) {
-        if (body != null || !classOrObject.hasModifier(KtTokens.EXPECT_KEYWORD)) {
+        if (body != null) {
           visitEnumBody(classOrObject as KtClass)
         }
       } else if (body != null) {

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -4512,8 +4512,7 @@ class FormatterTest {
 
   @Test
   fun `expect enum class`() =
-      assertFormatted(
-          """
+      assertFormatted("""
       |expect enum class ExpectedEnum
       |""".trimMargin())
 }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -3442,6 +3442,12 @@ class FormatterTest {
       |""".trimMargin())
 
   @Test
+  fun `expect enum class`() =
+      assertFormatted("""
+      |expect enum class ExpectedEnum
+      |""".trimMargin())
+
+  @Test
   fun `enum without trailing comma`() =
       assertFormatted(
           """
@@ -4508,11 +4514,5 @@ class FormatterTest {
       |  val y = 0
       |  y
       |}
-      |""".trimMargin())
-
-  @Test
-  fun `expect enum class`() =
-      assertFormatted("""
-      |expect enum class ExpectedEnum
       |""".trimMargin())
 }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -4509,4 +4509,11 @@ class FormatterTest {
       |  y
       |}
       |""".trimMargin())
+
+  @Test
+  fun `expect enum class`() =
+      assertFormatted(
+          """
+      |expect enum class ExpectedEnum
+      |""".trimMargin())
 }


### PR DESCRIPTION
Currently the parser breaks when encountering these in mutliplatform
projects.

Note that `kotlinc` also supports empty enum definitions.