### PR TITLE
Fix main class in pom file.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,7 +19,7 @@
         <kotlin.version>1.5.0</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
-        <main.class>com.facebook.ktfmt.MainKt</main.class>
+        <main.class>com.facebook.ktfmt.cli.Main</main.class>
     </properties>
 
     <pluginRepositories>


### PR DESCRIPTION
Building with `mvn install` currently results in a jar with a missing main class, as `main` was moved to core/src/main/java/com/facebook/ktfmt/cli/Main.kt