### PR TITLE
Update kotlin version to 1.6.10

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <dokka.version>0.10.1</dokka.version>
-        <kotlin.version>1.5.0</kotlin.version>
+        <kotlin.version>1.5.32</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <main.class>com.facebook.ktfmt.cli.Main</main.class>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <dokka.version>0.10.1</dokka.version>
-        <kotlin.version>1.5.32</kotlin.version>
+        <kotlin.version>1.6.10</kotlin.version>
         <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
         <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
         <main.class>com.facebook.ktfmt.cli.Main</main.class>


### PR DESCRIPTION
Running `mvn install` on macOS with JDK15 results in illegal access
exceptions. This appears to be a known issue that was fixed in 1.5.30:
https://youtrack.jetbrains.com/issue/KT-45689

It would be a nice quality of life improvement to bump the kotlin
version if this doesn't conflict with any internal flows.