### PR TITLE
Account for semicolons on top-level statements.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -2293,6 +2293,7 @@ class KotlinInputAstVisitor(
         builder.blankLineWanted(OpsBuilder.BlankLineWanted.YES)
       }
       visit(child)
+      builder.guessToken(";")
       lastChildHadBlankLineBefore = childGetsBlankLineBefore
       first = false
     }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -2929,6 +2929,31 @@ class FormatterTest {
       |""".trimMargin())
 
   @Test
+  fun `don't crash on top level statements with semicolons`() {
+    val code =
+      """
+      |val x = { 0 };
+      |
+      |foo({ 0 });
+      |
+      |foo { 0 };
+      |
+      |val fill = 0;
+      |""".trimMargin()
+    val expected =
+      """
+      |val x = { 0 }
+      |
+      |foo({ 0 })
+      |
+      |foo { 0 }
+      |
+      |val fill = 0
+      |""".trimMargin()
+    assertThatFormatting(code).isEqualTo(expected)
+  }
+
+  @Test
   fun `preserve semicolons in enums`() {
     val code =
         """


### PR DESCRIPTION
Before this, such semicolons caused a crash because OpBuilder noticed they were skipped in the token stream.