### PR TITLE
Preserve semicolons between call expressions and dead lambdas.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/RedundantElementRemover.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/RedundantElementRemover.kt
@@ -31,7 +31,7 @@ object RedundantElementRemover {
   fun dropRedundantElements(code: String, options: FormattingOptions): String {
     val file = Parser.parse(code)
     val redundantImportDetector = RedundantImportDetector(enabled = options.removeUnusedImports)
-    val redundantCommaDetector = RedundantCommaDetector()
+    val redundantSemicolonDetector = RedundantSemicolonDetector()
 
     file.accept(
         object : KtTreeVisitorVoid() {
@@ -39,7 +39,7 @@ object RedundantElementRemover {
             if (element is KDocImpl) {
               redundantImportDetector.takeKdoc(element)
             } else {
-              redundantCommaDetector.takeElement(element) { super.visitElement(element) }
+              redundantSemicolonDetector.takeElement(element) { super.visitElement(element) }
             }
           }
 
@@ -61,7 +61,7 @@ object RedundantElementRemover {
 
     val result = StringBuilder(code)
     val elementsToRemove =
-        redundantCommaDetector.getRedundantCommaElements() +
+        redundantSemicolonDetector.getRedundantSemicolonElements() +
             redundantImportDetector.getRedundantImportElements()
 
     for (element in elementsToRemove.sortedByDescending(PsiElement::endOffset)) {

--- a/core/src/main/java/com/facebook/ktfmt/format/RedundantSemicolonDetector.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/RedundantSemicolonDetector.kt
@@ -17,25 +17,29 @@
 package com.facebook.ktfmt.format
 
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
+import org.jetbrains.kotlin.psi.KtCallExpression
 import org.jetbrains.kotlin.psi.KtContainerNodeForControlStructureBody
 import org.jetbrains.kotlin.psi.KtDeclaration
 import org.jetbrains.kotlin.psi.KtEnumEntry
 import org.jetbrains.kotlin.psi.KtIfExpression
+import org.jetbrains.kotlin.psi.KtLambdaExpression
 import org.jetbrains.kotlin.psi.KtStringTemplateEntry
 import org.jetbrains.kotlin.psi.KtStringTemplateExpression
 import org.jetbrains.kotlin.psi.KtWhileExpression
 import org.jetbrains.kotlin.psi.psiUtil.prevLeaf
 import org.jetbrains.kotlin.psi.psiUtil.siblings
+import org.jetbrains.kotlin.psi.psiUtil.getNextSiblingIgnoringWhitespaceAndComments
+import org.jetbrains.kotlin.psi.psiUtil.getPrevSiblingIgnoringWhitespaceAndComments
 
-internal class RedundantCommaDetector {
-  private val extraCommas = mutableListOf<PsiElement>()
+internal class RedundantSemicolonDetector {
+  private val extraSemicolons = mutableListOf<PsiElement>()
 
-  fun getRedundantCommaElements(): List<PsiElement> = extraCommas
+  fun getRedundantSemicolonElements(): List<PsiElement> = extraSemicolons
 
   /** returns **true** if this element was an extra comma, **false** otherwise. */
   fun takeElement(element: PsiElement, superBlock: () -> Unit) {
     if (isExtraSemicolon(element)) {
-      extraCommas += element
+      extraSemicolons += element
     } else {
       superBlock.invoke()
     }
@@ -54,10 +58,14 @@ internal class RedundantCommaDetector {
       return false
     }
     val prevLeaf = element.prevLeaf(false)
-    val prevSibling = element.prevSibling
-    if ((prevSibling is KtIfExpression || prevSibling is KtWhileExpression) &&
+    val prevConcreteSibling = element.getPrevSiblingIgnoringWhitespaceAndComments()
+    if ((prevConcreteSibling is KtIfExpression || prevConcreteSibling is KtWhileExpression) &&
         prevLeaf is KtContainerNodeForControlStructureBody &&
         prevLeaf.text.isEmpty()) {
+      return false
+    }
+    val nextConcreteSibling = element.getNextSiblingIgnoringWhitespaceAndComments()
+    if (prevConcreteSibling is KtCallExpression && nextConcreteSibling is KtLambdaExpression) {
       return false
     }
 

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -2991,8 +2991,12 @@ class FormatterTest {
     val code =
         """
       |fun f() {
-      |  while (true) ;
+      |  while (true);
+      |  while (true) /** a */ ;
+      |
       |  if (true);
+      |  if (true) /** a */ ;
+      |
       |  if (true)
       |    else
       |  ;
@@ -3002,8 +3006,57 @@ class FormatterTest {
         """
       |fun f() {
       |  while (true) ;
+      |  while (true)
+      |  /** a */
+      |  ;
+      |
       |  if (true) ;
+      |  if (true)
+      |  /** a */
+      |  ;
+      |
       |  if (true)  else ;
+      |}
+      |""".trimMargin()
+    assertThatFormatting(code).isEqualTo(expected)
+  }
+
+  @Test
+  fun `preserve semicolons between calls and dead lambdas`() {
+    val code =
+        """
+      |fun f() {
+      |  foo(0); { dead -> lambda }
+      |
+      |  foo(0) ; { dead -> lambda }
+      |
+      |  foo(0) /** a */ ; /** b */ { dead -> lambda }
+      |
+      |  foo(0) { trailing -> lambda }; { dead -> lambda }
+      |
+      |  foo { trailing -> lambda }; { dead -> lambda }
+      |}
+      |""".trimMargin()
+    val expected =
+        """
+      |fun f() {
+      |  foo(0);
+      |  { dead -> lambda }
+      |
+      |  foo(0);
+      |  { dead -> lambda }
+      |
+      |  foo(0)
+      |  /** a */
+      |  ;
+      |  /** b */
+      |  { dead -> lambda }
+      |
+      |  foo(0) { trailing -> lambda };
+      |  { dead -> lambda }
+      |
+      |  foo { trailing -> lambda };
+      |  { dead -> lambda }
       |}
       |""".trimMargin()
     assertThatFormatting(code).isEqualTo(expected)


### PR DESCRIPTION
It's possible that removing such semicolons can change the behaviour of the code by reinterpreting the dead lambda as a trailing lambda.

This change also improves semicolon preservation when there are comments and whitespace adjacent to the semicolon.