### PR TITLE
Always break get/set definitions onto lines below the property declaration.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
@@ -82,7 +82,11 @@ object Formatter {
     val lfCode = StringUtilRt.convertLineSeparators(code)
     val sortedImports = sortedAndDistinctImports(lfCode)
     val pretty = prettyPrint(sortedImports, options, "\n")
-    val noRedundantElements = dropRedundantElements(pretty, options)
+    val noRedundantElements = try {
+      dropRedundantElements(pretty, options)
+    } catch (e: ParseError) {
+      throw IllegalStateException("Failed to re-parse code after pretty printing:\n $pretty", e)
+    }
     return prettyPrint(noRedundantElements, options, Newlines.guessLineSeparator(code)!!)
   }
 

--- a/core/src/main/java/com/facebook/ktfmt/format/RedundantSemicolonDetector.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/RedundantSemicolonDetector.kt
@@ -69,12 +69,6 @@ internal class RedundantSemicolonDetector {
       return false // Example: `foo(0); { dead -> lambda }`
     }
 
-    // do not remove `;` in `val a = 5; private set`
-    val nextSibling = element.nextSibling
-    if (nextSibling != null && '\n' !in nextSibling.text) {
-      return false
-    }
-
     return true
   }
 }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -383,14 +383,32 @@ class FormatterTest {
       |""".trimMargin())
 
   @Test
-  fun `properties with accessors and semicolons on same line`() =
-      assertFormatted(
+  fun `properties with accessors and semicolons on same line`() {
+    val code =
           """
       |class Foo {
       |  var x = false; private set
       |  internal val a by lazy { 5 }; internal get
+      |  var foo: Int; get() = 6; set(x) {};
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+
+    val expected =
+          """
+      |class Foo {
+      |  var x = false
+      |    private set
+      |  internal val a by lazy { 5 }
+      |    internal get
+      |  var foo: Int
+      |    get() = 6
+      |    set(x) {}
+      |}
+      |""".trimMargin()
+
+      assertThatFormatting(code).isEqualTo(expected)
+  }
+
 
   @Test
   fun `a property with a too long name being broken on multiple lines`() =


### PR DESCRIPTION
This change fixes a crash that occurs on code like `var foo: Int; get() = 0; set(x) { }`