### PR TITLE
Fix formatting of block-like lambdas (+ scope functions) on long lines.

### DIFF
--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -4326,6 +4326,17 @@ class FormatterTest {
       |  //
       |}
       |
+      |fun foo() = use { x ->
+      |  foo()
+      |  //
+      |}
+      |
+      |fun foo() =
+      |    coroutineScope { x ->
+      |      foo()
+      |      //
+      |    }
+      |
       |fun foo() =
       |    Runnable @Px
       |    {
@@ -4335,9 +4346,9 @@ class FormatterTest {
       |
       |fun longName() =
       |    coroutineScope {
-      |  foo()
-      |  //
-      |}
+      |      foo()
+      |      //
+      |    }
       |""".trimMargin(),
           deduceMaxWidth = true)
 

--- a/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
@@ -747,20 +747,6 @@ class GoogleStyleFormatterKtTest {
       |""".trimMargin())
 
   @Test
-  fun `assignment of a scoping function`() =
-      assertFormatted(
-          """
-      |----------------------------
-      |fun longName() =
-      |    coroutineScope {
-      |  foo()
-      |  //
-      |}
-      |""".trimMargin(),
-          formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
-
-  @Test
   fun `if expression with multiline condition`() =
       assertFormatted(
           """


### PR DESCRIPTION
If everything up to and including the `->` can fit on the current line, then indent only the lambda body. If we must break before the `->`, treat the lambda and scoping function as an expression, and indent the entire thing into a rectangle.