### PR TITLE
Fix crash on annotated destructuring declaration element.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1926,13 +1926,14 @@ class KotlinInputAstVisitor(
       multiDeclarationEntry: KtDestructuringDeclarationEntry
   ) {
     builder.sync(multiDeclarationEntry)
-    builder.token(multiDeclarationEntry.nameIdentifier?.text ?: fail())
-    val typeReference = multiDeclarationEntry.typeReference
-    if (typeReference != null) {
-      builder.token(":")
-      builder.space()
-      visit(typeReference)
-    }
+    declareOne(
+        initializer = null,
+        kind = DeclarationKind.PARAMETER,
+        modifiers = multiDeclarationEntry.modifierList,
+        name = multiDeclarationEntry.nameIdentifier?.text ?: fail(),
+        type = multiDeclarationEntry.typeReference,
+        valOrVarKeyword = null,
+    )
   }
 
   /** Example `"Hello $world!"` or `"""Hello world!"""` */

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -2549,6 +2549,12 @@ class FormatterTest {
       |""".trimMargin())
 
   @Test
+  fun `annotations on destructuring declaration elements`() =
+      assertFormatted("""
+      |val x = { (@Anno x, @Anno y) -> x }
+      |""".trimMargin())
+
+  @Test
   fun `annotations on exceptions`() =
       assertFormatted(
           """


### PR DESCRIPTION
e.g. `{ (@Anno x) -> x }`