### PR TITLE
Always break before `where` constraints on classes.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1395,8 +1395,10 @@ class KotlinInputAstVisitor(
       builder.space()
       val typeConstraintList = classOrObject.typeConstraintList
       if (typeConstraintList != null) {
-        visit(typeConstraintList)
-        builder.space()
+        builder.forcedBreak(expressionBreakIndent)
+        builder.blankLineWanted(OpsBuilder.BlankLineWanted.NO)
+        builder.block(expressionBreakIndent) { visit(typeConstraintList) }
+        builder.forcedBreak()
       }
       val body = classOrObject.body
       if (classOrObject.hasModifier(KtTokens.ENUM_KEYWORD)) {

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -2537,7 +2537,9 @@ class FormatterTest {
   fun `annotations on type constraints`() =
       assertFormatted(
           """
-      |class Foo<T : @Anno Kip, U> where U : @Anno Kip, U : @Anno Qux {
+      |class Foo<T : @Anno Kip, U>
+      |    where U : @Anno Kip, U : @Anno Qux
+      |{
       |  fun <T : @Anno Kip, U> bar() where U : @Anno Kip, U : @Anno Qux {}
       |}
       |""".trimMargin())
@@ -2607,7 +2609,17 @@ class FormatterTest {
   fun `handle compound generic bounds on classes`() =
       assertFormatted(
           """
-      |class Foo<T>(n: Int) where T : Bar, T : FooBar {}
+      |class Foo<T>(n: Int)
+      |    where T : Bar, T : FooBar
+      |{}
+      |
+      |class Foo<T>(n: Int) : Zip
+      |    where T : Bar, T : FooBar
+      |{}
+      |
+      |class Foo<T>(n: Int) : Zip by zip
+      |    where T : Bar, T : FooBar
+      |{}
       |""".trimMargin())
 
   @Test


### PR DESCRIPTION
This is the simplest reliable fix for the case:
```
class Foo<T> : Bar by bar // There needs to be a line break here or it's a parse error
    where T : Zap
{}
```