### PR TITLE
Proof of concept for propagating breaks along call expression blocklikes

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
@@ -114,7 +114,8 @@ object Formatter {
     val tokenRangeSet =
         kotlinInput.characterRangesToTokenRanges(ImmutableList.of(Range.closedOpen(0, code.length)))
     return WhitespaceTombstones.replaceTombstoneWithTrailingWhitespace(
-        JavaOutput.applyReplacements(code, javaOutput.getFormatReplacements(tokenRangeSet)))
+            JavaOutput.applyReplacements(code, javaOutput.getFormatReplacements(tokenRangeSet))
+        )
   }
 
   private fun createAstVisitor(options: FormattingOptions, builder: OpsBuilder): PsiElementVisitor {
@@ -133,7 +134,8 @@ object Formatter {
       throw ParseError(
           "ktfmt does not support code which contains one of {\\u0003, \\u0004, \\u0005} character" +
               "; escape it",
-          StringUtil.offsetToLineColumn(code, index))
+          StringUtil.offsetToLineColumn(code, index)
+      )
     }
   }
 
@@ -155,7 +157,8 @@ object Formatter {
       } else if (element !is KtImportDirective && element !is PsiWhiteSpace) {
         throw ParseError(
             "Imports not contiguous: " + element.text,
-            StringUtil.offsetToLineColumn(code, element.startOffset))
+            StringUtil.offsetToLineColumn(code, element.startOffset)
+        )
       }
       element = element.nextSibling
     }
@@ -170,8 +173,9 @@ object Formatter {
     val importsWithComments = commentList + sortedImports
 
     return code.replaceRange(
-        importList.startOffset,
-        importList.endOffset,
-        importsWithComments.joinToString(separator = "\n") { imprt -> imprt.text } + "\n")
+            importList.startOffset,
+            importList.endOffset,
+            importsWithComments.joinToString(separator = "\n") { imprt -> imprt.text } + "\n"
+        )
   }
 }

--- a/core/src/main/java/com/facebook/ktfmt/format/ParseError.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/ParseError.kt
@@ -20,4 +20,5 @@ import org.jetbrains.kotlin.com.intellij.openapi.util.text.LineColumn
 
 class ParseError(val errorDescription: String, val lineColumn: LineColumn) :
     IllegalArgumentException(
-        "${lineColumn.line + 1}:${lineColumn.column + 1}: error: $errorDescription")
+        "${lineColumn.line + 1}:${lineColumn.column + 1}: error: $errorDescription"
+    )

--- a/core/src/main/java/com/facebook/ktfmt/format/RedundantElementRemover.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/RedundantElementRemover.kt
@@ -34,30 +34,33 @@ object RedundantElementRemover {
     val redundantSemicolonDetector = RedundantSemicolonDetector()
 
     file.accept(
-        object : KtTreeVisitorVoid() {
-          override fun visitElement(element: PsiElement) {
-            if (element is KDocImpl) {
-              redundantImportDetector.takeKdoc(element)
-            } else {
-              redundantSemicolonDetector.takeElement(element) { super.visitElement(element) }
+            object : KtTreeVisitorVoid() {
+              override fun visitElement(element: PsiElement) {
+                if (element is KDocImpl) {
+                  redundantImportDetector.takeKdoc(element)
+                } else {
+                  redundantSemicolonDetector.takeElement(element) { super.visitElement(element) }
+                }
+              }
+
+              override fun visitPackageDirective(directive: KtPackageDirective) {
+                redundantImportDetector.takePackageDirective(directive) {
+                  super.visitPackageDirective(directive)
+                }
+              }
+
+              override fun visitImportList(importList: KtImportList) {
+                redundantImportDetector.takeImportList(importList) {
+                  super.visitImportList(importList)
+                }
+              }
+
+              override fun visitReferenceExpression(expression: KtReferenceExpression) {
+                redundantImportDetector.takeReferenceExpression(expression)
+                super.visitReferenceExpression(expression)
+              }
             }
-          }
-
-          override fun visitPackageDirective(directive: KtPackageDirective) {
-            redundantImportDetector.takePackageDirective(directive) {
-              super.visitPackageDirective(directive)
-            }
-          }
-
-          override fun visitImportList(importList: KtImportList) {
-            redundantImportDetector.takeImportList(importList) { super.visitImportList(importList) }
-          }
-
-          override fun visitReferenceExpression(expression: KtReferenceExpression) {
-            redundantImportDetector.takeReferenceExpression(expression)
-            super.visitReferenceExpression(expression)
-          }
-        })
+        )
 
     val result = StringBuilder(code)
     val elementsToRemove =

--- a/core/src/test/java/com/facebook/ktfmt/cli/MainTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/cli/MainTest.kt
@@ -150,7 +150,8 @@ class MainTest {
                       emptyInput,
                       PrintStream(out),
                       PrintStream(err),
-                      arrayOf(file1.toString(), file2Broken.toString(), file3.toString()))
+                      arrayOf(file1.toString(), file2Broken.toString(), file3.toString())
+                  )
                   .run()
             }
             .get()
@@ -178,7 +179,8 @@ class MainTest {
             emptyInput,
             PrintStream(out),
             PrintStream(err),
-            arrayOf("--dropbox-style", fooBar.toString()))
+            arrayOf("--dropbox-style", fooBar.toString())
+        )
         .run()
 
     assertThat(fooBar.readText()).isEqualTo(code)
@@ -193,7 +195,8 @@ class MainTest {
           |println(child)
           |}
           |}
-          |""".trimMargin()
+          |""".trimMargin(
+    )
     val formatted =
         """fun f() {
           |    for (child in
@@ -201,12 +204,14 @@ class MainTest {
           |        println(child)
           |    }
           |}
-          |""".trimMargin()
+          |""".trimMargin(
+    )
     Main(
             code.byteInputStream(),
             PrintStream(out),
             PrintStream(err),
-            arrayOf("--dropbox-style", "-"))
+            arrayOf("--dropbox-style", "-")
+        )
         .run()
 
     assertThat(out.toString("UTF-8")).isEqualTo(formatted)
@@ -241,7 +246,8 @@ class MainTest {
             """fun f (   ) =    println("hello, world")""".byteInputStream(),
             PrintStream(out),
             PrintStream(err),
-            arrayOf("-"))
+            arrayOf("-")
+        )
         .run()
     assertThat(out.toString("UTF-8")).isEqualTo(expected)
 
@@ -251,7 +257,8 @@ class MainTest {
             """fun f () = println("hello, world")""".byteInputStream(),
             PrintStream(out),
             PrintStream(err),
-            arrayOf("-"))
+            arrayOf("-")
+        )
         .run()
     assertThat(out.toString("UTF-8")).isEqualTo(expected)
   }
@@ -335,7 +342,8 @@ class MainTest {
                 emptyInput,
                 PrintStream(out),
                 PrintStream(err),
-                arrayOf("--set-exit-if-changed", file.toString()))
+                arrayOf("--set-exit-if-changed", file.toString())
+            )
             .run()
 
     assertThat(exitCode).isEqualTo(1)
@@ -350,7 +358,8 @@ class MainTest {
                 code.byteInputStream(),
                 PrintStream(out),
                 PrintStream(err),
-                arrayOf("--set-exit-if-changed", "-"))
+                arrayOf("--set-exit-if-changed", "-")
+            )
             .run()
 
     assertThat(exitCode).isEqualTo(1)
@@ -367,7 +376,8 @@ class MainTest {
                 emptyInput,
                 PrintStream(out),
                 PrintStream(err),
-                arrayOf("--dry-run", "--set-exit-if-changed", file.toString()))
+                arrayOf("--dry-run", "--set-exit-if-changed", file.toString())
+            )
             .run()
 
     assertThat(file.readText()).isEqualTo(code)
@@ -384,7 +394,8 @@ class MainTest {
                 code.byteInputStream(),
                 PrintStream(out),
                 PrintStream(err),
-                arrayOf("--dry-run", "--set-exit-if-changed", "-"))
+                arrayOf("--dry-run", "--set-exit-if-changed", "-")
+            )
             .run()
 
     assertThat(out.toString("UTF-8")).doesNotContain("hello, world")

--- a/core/src/test/java/com/facebook/ktfmt/cli/ParsedArgsTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/cli/ParsedArgsTest.kt
@@ -20,10 +20,7 @@ import com.facebook.ktfmt.format.Formatter
 import com.facebook.ktfmt.format.FormattingOptions
 import com.google.common.truth.Truth.assertThat
 import java.io.ByteArrayOutputStream
-import java.io.FileNotFoundException
 import java.io.PrintStream
-import junit.framework.Assert.fail
-import org.junit.After
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.JUnit4
@@ -31,13 +28,6 @@ import org.junit.runners.JUnit4
 @Suppress("FunctionNaming")
 @RunWith(JUnit4::class)
 class ParsedArgsTest {
-
-  private val root = createTempDir()
-
-  @After
-  fun tearDown() {
-    root.deleteRecursively()
-  }
 
   @Test
   fun `files to format are returned and unknown flags are reported`() {
@@ -47,16 +37,6 @@ class ParsedArgsTest {
 
     assertThat(fileNames).containsExactly("foo.kt")
     assertThat(out.toString()).isEqualTo("Unexpected option: --unknown\n")
-  }
-
-  @Test
-  fun `files to format are returned and flags starting with @ are reported`() {
-    val out = ByteArrayOutputStream()
-
-    val (fileNames, _) = ParsedArgs.parseOptions(PrintStream(out), arrayOf("foo.kt", "@unknown"))
-
-    assertThat(fileNames).containsExactly("foo.kt")
-    assertThat(out.toString()).isEqualTo("Unexpected option: @unknown\n")
   }
 
   @Test
@@ -126,31 +106,5 @@ class ParsedArgsTest {
         ParsedArgs.parseOptions(PrintStream(out), arrayOf("--set-exit-if-changed", "foo.kt"))
 
     assertThat(parsed.setExitIfChanged).isTrue()
-  }
-
-  @Test
-  fun `processArgs use the @file option with non existing file`() {
-    val out = ByteArrayOutputStream()
-
-    try {
-      ParsedArgs.processArgs(PrintStream(out), arrayOf("@non-existing-file"))
-      fail("expected an exception of type FileNotFoundException but nothing was thrown")
-    } catch (e: FileNotFoundException) {
-      assertThat(e.message).contains("non-existing-file (No such file or directory)")
-    }
-  }
-
-  @Test
-  fun `processArgs use the @file option with file containing arguments`() {
-    val out = ByteArrayOutputStream()
-    val file = root.resolve("existing-file")
-    file.writeText("--google-style\n--dry-run\n--set-exit-if-changed\nFile1.kt\nFile2.kt\n")
-
-    val parsed = ParsedArgs.processArgs(PrintStream(out), arrayOf("@" + file.absolutePath))
-
-    assertThat(parsed.formattingOptions).isEqualTo(Formatter.GOOGLE_FORMAT)
-    assertThat(parsed.dryRun).isTrue()
-    assertThat(parsed.setExitIfChanged).isTrue()
-    assertThat(parsed.fileNames).containsExactlyElementsIn(listOf("File1.kt", "File2.kt"))
   }
 }

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -47,7 +47,9 @@ class FormatterTest {
         |println("Called with args:")
         |
         |args.forEach { println(File + "-") }
-        |""".trimMargin())
+        |""".trimMargin(
+      )
+      )
 
   @Test
   fun `call chains`() =
@@ -84,8 +86,10 @@ class FormatterTest {
       |      .add(1)
       |      .build()
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `line breaks in function arguments`() =
@@ -106,8 +110,10 @@ class FormatterTest {
       |  doc.computeBreaks(
       |      output.commentsHelper, maxWidth, State(0))
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `parameters and return type in function definitions`() =
@@ -129,8 +135,10 @@ class FormatterTest {
       |) {
       |  val a = 0
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `kitchen sink of tests`() {
@@ -160,7 +168,8 @@ class FormatterTest {
         |
         |          ImmutableList.newBuilder().add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).build()
         |     }
-        |""".trimMargin()
+        |""".trimMargin(
+    )
 
     val expected =
         """
@@ -201,7 +210,8 @@ class FormatterTest {
         |      .add(1)
         |      .build()
         |}
-        |""".trimMargin()
+        |""".trimMargin(
+    )
 
     assertThatFormatting(code).isEqualTo(expected)
     // Don't add more tests here
@@ -215,7 +225,9 @@ class FormatterTest {
       |  var x: Int = 4
       |  val y = 0
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test fun `class without a body nor properties`() = assertFormatted("class Foo\n")
 
@@ -229,7 +241,8 @@ class FormatterTest {
           """fun interface MyRunnable {
         |  fun runIt()
         |}
-        |""".trimMargin())
+        |""".trimMargin()
+      )
 
   @Test
   fun `handle complex fun interface without body`() =
@@ -248,7 +261,9 @@ class FormatterTest {
       |  fun method() {}
       |  class Bar
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `properties and fields with modifiers`() =
@@ -260,7 +275,9 @@ class FormatterTest {
       |  open var f3 = 0
       |  final var f4 = 0
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `properties with multiple modifiers`() =
@@ -269,7 +286,9 @@ class FormatterTest {
       |class Foo(public open inner val p1: Int) {
       |  public open inner var f2 = 0
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `spaces around binary operations`() =
@@ -279,7 +298,8 @@ class FormatterTest {
       |  a = 5
       |  x + 1
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `breaking long binary operations`() =
@@ -300,8 +320,10 @@ class FormatterTest {
       |              value8) +
       |          value9
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `prioritize according to associativity`() =
@@ -312,8 +334,10 @@ class FormatterTest {
       |  return expression1 != expression2 ||
       |      expression2 != expression1
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `once a binary expression is broken, split on every line`() =
@@ -331,8 +355,10 @@ class FormatterTest {
         |          "lazy" +
         |          "dog"
         |}
-        |""".trimMargin(),
-          deduceMaxWidth = true)
+        |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `long binary expressions with ranges in the middle`() =
@@ -348,8 +374,10 @@ class FormatterTest {
         |          "over" +
         |          "the".."lazy" + "dog"
         |}
-        |""".trimMargin(),
-          deduceMaxWidth = true)
+        |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `assignment expressions with scoping functions are block-like`() =
@@ -403,8 +431,10 @@ class FormatterTest {
         |        //
         |      }
         |}
-        |""".trimMargin(),
-          deduceMaxWidth = true)
+        |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `don't keep adding newlines between these two comments when they're at end of file`() =
@@ -414,7 +444,8 @@ class FormatterTest {
      |// a
      |
      |/* Another comment */
-     |""".trimMargin())
+     |""".trimMargin()
+      )
 
   @Test
   fun `properties with accessors`() =
@@ -435,7 +466,9 @@ class FormatterTest {
       |  var zz = false
       |    private set
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `properties with accessors and semicolons on same line`() {
@@ -446,7 +479,8 @@ class FormatterTest {
       |  internal val a by lazy { 5 }; internal get
       |  var foo: Int; get() = 6; set(x) {};
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
 
     val expected =
         """
@@ -459,7 +493,8 @@ class FormatterTest {
       |    get() = 6
       |    set(x) {}
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
 
     assertThatFormatting(code).isEqualTo(expected)
   }
@@ -475,8 +510,10 @@ class FormatterTest {
       |      "Hello there this is long"
       |    get() = field
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `multi-character unary and binary operators such as ==`() =
@@ -488,7 +525,9 @@ class FormatterTest {
       |  a++
       |  a === b
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `package names stay in one line`() {
@@ -497,7 +536,8 @@ class FormatterTest {
       | package  com  .example. subexample
       |
       |fun f() = 1
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |package com.example.subexample
@@ -517,7 +557,9 @@ class FormatterTest {
       |import `nothing stops`.`us`.`from doing this`
       |
       |fun f() = `from doing this`()
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `safe dot operator expression`() =
@@ -534,7 +576,8 @@ class FormatterTest {
       |fun f() {
       |  node?.name.hello
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `safe dot operator expression chain in expression function`() =
@@ -543,8 +586,10 @@ class FormatterTest {
       |--------------------------------------------------
       |fun f(number: Int) =
       |    Something.doStuff(number)?.size
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `avoid breaking suspected package names`() =
@@ -565,8 +610,10 @@ class FormatterTest {
       |  foo.facebook.Foo
       |      .format()
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `an assortment of tests for emitQualifiedExpression`() =
@@ -615,8 +662,10 @@ class FormatterTest {
       |      .methodName4()
       |      .abcdefghijkl()
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `an assortment of tests for emitQualifiedExpression with lambdas`() =
@@ -689,8 +738,10 @@ class FormatterTest {
       |            foo
       |          }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `indent parameters after a break when there's a lambda afterwards`() =
@@ -707,8 +758,10 @@ class FormatterTest {
       |        }
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `no break between multi-line strings and their selectors`() =
@@ -726,8 +779,10 @@ class FormatterTest {
       |    ""${'"'}
       |    |foo
       |    |----------------------------------""${'"'}.trimMargin()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `import list`() {
@@ -741,7 +796,8 @@ class FormatterTest {
       |                  test */
       |
       |val x = FooBar.def { foosBars(bar) }
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |import abc.def /*
@@ -752,7 +808,8 @@ class FormatterTest {
       |import foo.bar // Test
       |
       |val x = FooBar.def { foosBars(bar) }
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -762,7 +819,8 @@ class FormatterTest {
         """
         |import com.example.zab // test
         |import com.example.foo ; val x = Sample(foo, zab)
-        |""".trimMargin()
+        |""".trimMargin(
+    )
 
     val expected =
         """
@@ -770,7 +828,8 @@ class FormatterTest {
         |import com.example.zab // test
         |
         |val x = Sample(foo, zab)
-        |""".trimMargin()
+        |""".trimMargin(
+    )
 
     assertThatFormatting(code).isEqualTo(expected)
   }
@@ -785,7 +844,9 @@ class FormatterTest {
       |import com.example.wow
       |
       |val x = `if` { we.`when`(wow) }
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `backticks are ignored in import sort order ('as' directory)`() =
@@ -797,7 +858,9 @@ class FormatterTest {
       |import com.example.a as wow
       |
       |val x = `if` { we.`when`(wow) }
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `imports are deduplicated`() {
@@ -812,7 +875,8 @@ class FormatterTest {
       |import com.example.a as `when`
       |
       |val x = `if` { we.`when`(wow) } ?: b
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |import com.example.a as `if`
@@ -823,7 +887,8 @@ class FormatterTest {
       |import com.example.b.*
       |
       |val x = `if` { we.`when`(wow) } ?: b
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -846,7 +911,8 @@ class FormatterTest {
       |  `if` { bar }
       |  val x = unused()
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |import com.used.FooBarBaz as Baz
@@ -861,7 +927,8 @@ class FormatterTest {
       |  `if` { bar }
       |  val x = unused()
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -878,7 +945,8 @@ class FormatterTest {
       |fun test() {
       |  foo(CONSTANT, Sample())
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |package com.example
@@ -889,7 +957,8 @@ class FormatterTest {
       |fun test() {
       |  foo(CONSTANT, Sample())
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -926,7 +995,8 @@ class FormatterTest {
           | * @throws AnException
           | */
           |class Dummy
-          |""".trimMargin()
+          |""".trimMargin(
+    )
     val expected =
         """
           |package com.example.kdoc
@@ -955,7 +1025,8 @@ class FormatterTest {
           | * @throws AnException
           | */
           |class Dummy
-          |""".trimMargin()
+          |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -970,7 +1041,9 @@ class FormatterTest {
           |import com.example.component3
           |import com.example.component4
           |import com.example.component5
-          |""".trimMargin())
+          |""".trimMargin(
+      )
+      )
 
   @Test
   fun `keep operator imports`() =
@@ -1008,7 +1081,9 @@ class FormatterTest {
           |import com.example.timesAssign
           |import com.example.unaryMinus
           |import com.example.unaryPlus
-          |""".trimMargin())
+          |""".trimMargin(
+      )
+      )
 
   @Test
   fun `keep unused imports when formatting options has feature turned off`() {
@@ -1023,7 +1098,8 @@ class FormatterTest {
       |import com.unused.b as we
       |import com.unused.bar // test
       |import com.unused.`class`
-      |""".trimMargin()
+      |""".trimMargin(
+    )
 
     assertThatFormatting(code)
         .withOptions(FormattingOptions(removeUnusedImports = false))
@@ -1045,7 +1121,8 @@ class FormatterTest {
         |// trailing comment
         |
         |val x = Sample(abc, bcd)
-        |""".trimMargin()
+        |""".trimMargin(
+    )
     val expected =
         """
         |package com.facebook.ktfmt
@@ -1060,7 +1137,8 @@ class FormatterTest {
         |// trailing comment
         |
         |val x = Sample(abc, bcd)
-        |""".trimMargin()
+        |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -1073,7 +1151,9 @@ class FormatterTest {
         |/*
         |bar
         |*/
-        |""".trimMargin())
+        |""".trimMargin(
+      )
+      )
 
   @Test
   fun `basic annotations`() =
@@ -1086,7 +1166,9 @@ class FormatterTest {
       |    @Fancy val a = 1 + foo
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `function calls with multiple arguments`() =
@@ -1100,7 +1182,9 @@ class FormatterTest {
       |      123456789012345678901234567890,
       |      123456789012345678901234567890)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `function calls with multiple named arguments`() =
@@ -1114,7 +1198,9 @@ class FormatterTest {
       |      b = 23456789012345678901234567890,
       |      c = 3456789012345678901234567890)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `named arguments indent their value expression`() =
@@ -1128,7 +1214,9 @@ class FormatterTest {
       |              print()
       |            },
       |        duration = duration)
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `Arguments are blocks`() =
@@ -1154,8 +1242,10 @@ class FormatterTest {
       |        initializer = property.initializer)
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `anonymous function`() =
@@ -1167,7 +1257,9 @@ class FormatterTest {
       |        println(number)
       |      })
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `anonymous function with receiver`() =
@@ -1179,7 +1271,9 @@ class FormatterTest {
       |        println(this)
       |      })
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() with a subject expression`() =
@@ -1197,7 +1291,9 @@ class FormatterTest {
       |    }
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression with complex predicates`() =
@@ -1212,7 +1308,9 @@ class FormatterTest {
       |    }
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression with several conditions`() =
@@ -1224,7 +1322,9 @@ class FormatterTest {
       |    else -> print(0)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression with is and in`() =
@@ -1242,7 +1342,9 @@ class FormatterTest {
       |    else -> print(3)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression with enum values`() =
@@ -1255,7 +1357,9 @@ class FormatterTest {
       |    else -> print(3)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression with generic matcher and exhaustive`() =
@@ -1267,7 +1371,9 @@ class FormatterTest {
       |    is Failure -> print(2)
       |  }.exhaustive
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression with multiline condition`() =
@@ -1290,8 +1396,10 @@ class FormatterTest {
       |    2 -> print(2)
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `lambda assigned to variable does not break before brace`() =
@@ -1308,7 +1416,9 @@ class FormatterTest {
       |  doItOnce()
       |  doItTwice()
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `when() expression storing in local variable`() =
@@ -1320,7 +1430,9 @@ class FormatterTest {
       |    is Failure -> print(2)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `line breaks inside when expressions and conditions`() =
@@ -1341,7 +1453,9 @@ class FormatterTest {
       |      }
       |      .build()
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `function return types`() =
@@ -1350,7 +1464,8 @@ class FormatterTest {
       |fun f1(): Int = 0
       |
       |fun f2(): Int {}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `multi line function without a block body`() =
@@ -1363,8 +1478,10 @@ class FormatterTest {
       |
       |fun shortFun(): Int =
       |    1234567 + 1234567
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `return type doesn't fit in one line`() =
@@ -1386,8 +1503,10 @@ class FormatterTest {
       |    //
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `list of superclasses`() =
@@ -1402,7 +1521,9 @@ class FormatterTest {
       |class Derived4 : Super1()
       |
       |class Derived5 : Super3<Int>()
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `list of superclasses over multiple lines`() =
@@ -1425,8 +1546,10 @@ class FormatterTest {
       |
       |class Derived5 :
       |    Super3<Int>()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `annotations with parameters`() =
@@ -1451,7 +1574,9 @@ class FormatterTest {
       |final class Foo
       |
       |open class Foo
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `kdoc comments`() {
@@ -1479,7 +1604,8 @@ class FormatterTest {
       | */ class F {
       |
       | }
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected = """
       |/** foo /* bla */ */
       |class F {}
@@ -1497,7 +1623,9 @@ class FormatterTest {
       | * ```
       | */
       |fun foo() {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `formatting kdoc doesn't add p HTML tags`() =
@@ -1511,7 +1639,9 @@ class FormatterTest {
       | *
       | * <p>On the other hand, we respect existing tags, and don't remove them.
       | */
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `formatting kdoc preserves lists`() =
@@ -1524,7 +1654,9 @@ class FormatterTest {
       | *
       | * This is another paragraph
       | */
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `formatting kdoc lists with line wraps breaks and merges correctly`() {
@@ -1538,7 +1670,8 @@ class FormatterTest {
       | *
       | * This is another paragraph
       | */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/**
@@ -1549,7 +1682,8 @@ class FormatterTest {
       | *
       | * This is another paragraph
       | */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -1562,7 +1696,8 @@ class FormatterTest {
       | * - Banana Banana Banana Banana Banana Banana Banana Banana Banana Banana Banana Banana Banana
       | *     Banana Banana Banana Banana Banana
       | */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/**
@@ -1572,7 +1707,8 @@ class FormatterTest {
       | *     Banana Banana Banana Banana Banana
       | * ```
       | */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -1587,7 +1723,8 @@ class FormatterTest {
       | *
       | * This is not code again
       | */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/**
@@ -1597,7 +1734,8 @@ class FormatterTest {
       | * ```
       | * This is not code again
       | */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -1612,7 +1750,9 @@ class FormatterTest {
       | *
       | * This is another paragraph
       | */
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `formatting kdoc preserves numbered`() =
@@ -1625,7 +1765,9 @@ class FormatterTest {
       | *
       | * This is another paragraph
       | */
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `return statement with value`() =
@@ -1634,7 +1776,8 @@ class FormatterTest {
       |fun random(): Int {
       |  return 4
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `return statement without value`() =
@@ -1644,7 +1787,9 @@ class FormatterTest {
       |  print(b)
       |  return
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `return expression without value`() =
@@ -1653,7 +1798,9 @@ class FormatterTest {
       |fun print(b: Boolean?) {
       |  print(b ?: return)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `if statement without else`() =
@@ -1664,7 +1811,9 @@ class FormatterTest {
       |    println(b)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `if statement with else`() =
@@ -1677,7 +1826,9 @@ class FormatterTest {
       |    println(1)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `if expression with else`() =
@@ -1692,7 +1843,9 @@ class FormatterTest {
       |      } else 2)
       |  return if (b) 1 else 2
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `if expression with break before else`() =
@@ -1706,8 +1859,10 @@ class FormatterTest {
       |  return if (a + b < 20) a + b
       |  else c
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `if expression with break before expressions`() =
@@ -1725,8 +1880,10 @@ class FormatterTest {
       |      a + b
       |  else c
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `blocky expressions in if-else`() =
@@ -1743,7 +1900,9 @@ class FormatterTest {
       |        println("Everything is okay")
       |      }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `if expression with multiline condition`() =
@@ -1764,8 +1923,10 @@ class FormatterTest {
       |    bar()
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `assignment expression on multiple lines`() =
@@ -1777,8 +1938,10 @@ class FormatterTest {
       |  myVariable =
       |      function1(4, 60, 8) + function2(57, 39, 20)
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `A program that tickled a bug in KotlinInput`() =
@@ -1808,7 +1971,9 @@ class FormatterTest {
       |    number5: Int,
       |    number6: Int
       |) {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `a primary constructor without a class body `() =
@@ -1818,8 +1983,10 @@ class FormatterTest {
       |data class Foo(
       |    val number: Int = 0
       |)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a secondary constructor without a body`() =
@@ -1831,8 +1998,10 @@ class FormatterTest {
       |      val number: Int = 0
       |  )
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a secondary constructor with a body breaks before closing parenthesis`() =
@@ -1844,8 +2013,10 @@ class FormatterTest {
       |      val number: Int = 0
       |  ) {}
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a constructor with many arguments over breaking to next line`() =
@@ -1858,7 +2029,9 @@ class FormatterTest {
       |    val title: String,
       |    val offspring2: List<Foo>
       |) {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `a constructor with keyword and many arguments over breaking to next line`() =
@@ -1872,7 +2045,9 @@ class FormatterTest {
       |    val offspring: List<Foo>,
       |    val foo: String
       |) {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `a constructor with many arguments over multiple lines`() =
@@ -1887,8 +2062,10 @@ class FormatterTest {
       |    val title: String,
       |    val offspring: List<Foo>
       |) {}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle secondary constructors`() =
@@ -1900,7 +2077,9 @@ class FormatterTest {
       |    println("built")
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `a secondary constructor with many arguments over multiple lines`() =
@@ -1916,8 +2095,10 @@ class FormatterTest {
       |      val offspring: List<Foo>
       |  )
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a secondary constructor with many arguments passed to delegate`() =
@@ -1939,8 +2120,10 @@ class FormatterTest {
       |      offspring,
       |      offspring)
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a secondary constructor with no arguments passed to delegate`() =
@@ -1954,8 +2137,10 @@ class FormatterTest {
       |          Foo.createSpeciallyDesignedParameter(),
       |      )
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `secondary constructor with param list that fits in one line, with delegate`() =
@@ -1971,7 +2156,9 @@ class FormatterTest {
       |    init(attrs)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle calling super constructor in secondary constructor`() =
@@ -1980,7 +2167,9 @@ class FormatterTest {
       |class Foo : Bar {
       |  internal constructor(number: Int) : super(number) {}
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle super statement with with type argument`() =
@@ -1991,7 +2180,9 @@ class FormatterTest {
       |    super<FooBar>.doIt()
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle super statement with with label argument`() =
@@ -2007,7 +2198,9 @@ class FormatterTest {
       |    }
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `primary constructor without parameters with a KDoc`() =
@@ -2016,7 +2209,9 @@ class FormatterTest {
       |class Class
       |/** A comment */
       |constructor() {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle objects`() = assertFormatted("""
@@ -2030,7 +2225,9 @@ class FormatterTest {
       |fun f(): Any {
       |  return object : Adapter() {}
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle object expression in parenthesis`() =
@@ -2039,7 +2236,9 @@ class FormatterTest {
       |fun f(): Any {
       |  return (object : Adapter() {})
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle array indexing operator`() =
@@ -2049,7 +2248,9 @@ class FormatterTest {
       |  a[3]
       |  b[3, 4]
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle destructuring declaration`() =
@@ -2065,8 +2266,10 @@ class FormatterTest {
       |      oneTwoThreeFourFiveSixSeven(
       |          foo, bar, zed, boo)
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle ? for nullalble types`() =
@@ -2077,7 +2280,9 @@ class FormatterTest {
       |}
       |
       |fun doItWithNulls(a: String, b: String?) {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `nullable function type`() =
@@ -2092,7 +2297,9 @@ class FormatterTest {
       |val a: (Int) = 7
       |
       |var listener: ((Boolean) -> Unit) = foo
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle string literals`() =
@@ -2103,7 +2310,9 @@ class FormatterTest {
       |  println("Hello! ${'$'}world")
       |  println("Hello! ${'$'}{"wor" + "ld"}")
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle multiline string literals`() =
@@ -2113,7 +2322,9 @@ class FormatterTest {
       |  println(${"\"".repeat(3)}Hello
       |      world!${"\"".repeat(3)})
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `Trailing whitespaces are preserved in multiline strings`() {
@@ -2129,7 +2340,8 @@ class FormatterTest {
                 "  println(\"\"\"This line has trailing whitespace \$      ",
                 "      world!\"\"\")",
                 "}",
-                "")
+                ""
+            )
             .joinToString("\n")
     assertThatFormatting(code).allowTrailingWhitespace().isEqualTo(code)
   }
@@ -2144,7 +2356,9 @@ class FormatterTest {
       |
       |Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
       |""${'"'}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `Trailing spaces in a comment are not preserved`() {
@@ -2181,7 +2395,9 @@ class FormatterTest {
       |}
       |
       |class Foo<T>
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle for loops`() =
@@ -2192,7 +2408,9 @@ class FormatterTest {
       |    println(i)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle for loops with long dot chains`() =
@@ -2213,8 +2431,10 @@ class FormatterTest {
       |    println(child)
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `when two lambdas following a call, indent the lambda properly`() =
@@ -2231,8 +2451,10 @@ class FormatterTest {
       |        number = 2 * number
       |      }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `when two lambdas following a field, indent the lambda properly`() =
@@ -2249,8 +2471,10 @@ class FormatterTest {
       |        number = 2 * number
       |      }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `break after 'four' (even though it's 4 chars long) because there's a lambda afterwards`() =
@@ -2264,7 +2488,9 @@ class FormatterTest {
       |      }
       |      .methodCall()
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `keep last expression in qualified indented`() =
@@ -2280,8 +2506,10 @@ class FormatterTest {
       |          Foo.doIt()
       |              .doThat())
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `properly place lambda arguments into blocks`() =
@@ -2297,8 +2525,10 @@ class FormatterTest {
       |    red.orange.yellow()
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `properly handle one statement lambda with comment`() =
@@ -2327,8 +2557,10 @@ class FormatterTest {
       |    red.orange.yellow()
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `properly handle one statement lambda with comment after body statements`() =
@@ -2359,8 +2591,10 @@ class FormatterTest {
       |  red.orange.yellow()
       |  // this is a comment
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `try to keep expression in the same line until the first lambda`() =
@@ -2383,8 +2617,10 @@ class FormatterTest {
       |        action2()
       |      }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `different indentation in chained calls`() =
@@ -2400,8 +2636,10 @@ class FormatterTest {
       |          foo1, foo2, foo3)
       |      .doThat()
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `always add a conditional break for a lambda which is not last`() =
@@ -2417,8 +2655,10 @@ class FormatterTest {
       |        doStuff()
       |      }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `keep parenthesis and braces together when there's only one lambda argument`() =
@@ -2438,7 +2678,9 @@ class FormatterTest {
       |        a + a
       |      })
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `Qualified type`() =
@@ -2449,7 +2691,9 @@ class FormatterTest {
       |  var x: Map.Entry<String, Integer>
       |  var x: List<String>.Iterator
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle destructuring declaration in for loop`() =
@@ -2458,7 +2702,9 @@ class FormatterTest {
       |fun f(a: List<Pair<Int, Int>>) {
       |  for ((x, y: Int) in a) {}
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle function references`() =
@@ -2469,7 +2715,9 @@ class FormatterTest {
       |  a.map(Int::toString)
       |  a.map(String?::isNullOrEmpty)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle escaped identifier`() =
@@ -2486,7 +2734,9 @@ class FormatterTest {
       |}
       |
       |class `more spaces`
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle annotations with arguments`() =
@@ -2501,7 +2751,9 @@ class FormatterTest {
       |class Test {
       |  //
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `no newlines after annotations if entire expr fits in one line`() =
@@ -2558,8 +2810,10 @@ class FormatterTest {
       |    println("")
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `no newlines after annotations on properties if entire expression fits in one line`() =
@@ -2569,8 +2823,10 @@ class FormatterTest {
       |@Suppress("UnsafeCast")
       |val ClassA.methodA
       |  get() = foo as Bar
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `when annotations cause line breaks, and constant has no type dont break before value`() =
@@ -2582,15 +2838,19 @@ class FormatterTest {
       |  @LongLongLongLongLongAnnotation
       |  private val ROW_HEIGHT = 72
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `annotations in literal function types`() =
       assertFormatted(
           """
       |val callback: (@Anno List<@JvmSuppressWildcards String>) -> Unit = foo
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `annotations on type parameters`() =
@@ -2599,7 +2859,9 @@ class FormatterTest {
       |class Foo<@Anno out @Anno T, @Anno in @Anno U> {
       |  inline fun <@Anno reified @Anno X, @Anno reified @Anno Y> bar() {}
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `annotations on type constraints`() =
@@ -2608,7 +2870,9 @@ class FormatterTest {
       |class Foo<T : @Anno Kip, U> where U : @Anno Kip, U : @Anno Qux {
       |  fun <T : @Anno Kip, U> bar() where U : @Anno Kip, U : @Anno Qux {}
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `annotations on type arguments`() =
@@ -2633,7 +2897,9 @@ class FormatterTest {
       |    //
       |  } catch (@Suppress("GeneralException") e: Exception) {}
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `Unary expressions`() =
@@ -2647,7 +2913,9 @@ class FormatterTest {
       |  ++a
       |  --a
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle wildcard generics`() =
@@ -2657,7 +2925,9 @@ class FormatterTest {
       |  val l: List<*>
       |  val p: Pair<*, *>
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle covariant and contravariant type arguments`() =
@@ -2682,14 +2952,16 @@ class FormatterTest {
       assertFormatted(
           """
       |class Foo<T>(n: Int) where T : Bar, T : FooBar {}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle compound generic bounds on functions`() =
       assertFormatted(
           """
       |fun <T> foo(n: Int) where T : Bar, T : FooBar {}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle compound generic bounds on properties`() =
@@ -2699,7 +2971,9 @@ class FormatterTest {
       |  get() {
       |    return 2 * sum()
       |  }
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle compound generic bounds on class with delegate`() =
@@ -2707,7 +2981,8 @@ class FormatterTest {
           """
       |class Foo<T>() : Bar by bar
       |where T : Qux
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `explicit type on property getter`() =
@@ -2717,7 +2992,9 @@ class FormatterTest {
       |  val silly: Int
       |    get(): Int = 1
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle method calls with lambda arg only`() =
@@ -2726,7 +3003,8 @@ class FormatterTest {
       |fun f() {
       |  val a = g { 1 + 1 }
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle method calls value args and a lambda arg`() =
@@ -2735,7 +3013,8 @@ class FormatterTest {
       |fun f() {
       |  val a = g(1, 2) { 1 + 1 }
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle top level constants`() =
@@ -2747,8 +3026,10 @@ class FormatterTest {
       |const val b = "a"
       |
       |val a = 5
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle lambda arg with named arguments`() =
@@ -2757,7 +3038,9 @@ class FormatterTest {
       |fun f() {
       |  val b = { x: Int, y: Int -> x + y }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `avoid newline before lambda argument if it is named`() =
@@ -2771,7 +3054,9 @@ class FormatterTest {
       |        step2()
       |      }) { it.doIt() }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle labeled this pointer`() =
@@ -2782,7 +3067,9 @@ class FormatterTest {
       |    g { println(this@Foo) }
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle extension and operator functions`() =
@@ -2796,7 +3083,9 @@ class FormatterTest {
           """
       |val Int.isPrime: Boolean
       |  get() = runMillerRabinPrimality(this)
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `generic extension property`() =
@@ -2817,7 +3106,9 @@ class FormatterTest {
       |class Foo {
       |  val a = example2("and 1")
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle init block`() =
@@ -2828,14 +3119,17 @@ class FormatterTest {
       |    println("Init!")
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle interface delegation`() =
       assertFormatted(
           """
       |class MyList(impl: List<Int>) : Collection<Int> by impl
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle property delegation`() =
@@ -2862,8 +3156,10 @@ class FormatterTest {
       |
       |val importantValue: Int by
       |    doIt(1 + 1)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle multi-annotations with use-site targets`() =
@@ -2881,7 +3177,9 @@ class FormatterTest {
     |  var httpClient: OkHttpClient
     |}
     |
-    """.trimMargin())
+    """.trimMargin(
+      )
+      )
 
   @Test
   fun `handle parameters with annoations with parameters`() =
@@ -2893,7 +3191,9 @@ class FormatterTest {
     |  }
     |}
     |
-    """.trimMargin())
+    """.trimMargin(
+      )
+      )
 
   @Test
   fun `handle lambda types`() =
@@ -2906,7 +3206,9 @@ class FormatterTest {
       |val listener3: (Int, Double) -> Int = { a, b -> a }
       |
       |val listener4: Int.(Int, Boolean) -> Unit
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle unicode in string literals`() =
@@ -2924,7 +3226,9 @@ class FormatterTest {
       |  doIt(o as Int)
       |  doIt(o as? Int)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle casting with breaks`() =
@@ -2954,8 +3258,10 @@ class FormatterTest {
       |      a is Int &&
       |          b is String)
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle collection literals in annotations`() =
@@ -2965,7 +3271,9 @@ class FormatterTest {
       |fun doIt(o: Object) {
       |  //
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle try, catch and finally`() =
@@ -2980,7 +3288,9 @@ class FormatterTest {
       |    println("finally")
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle infix methods`() =
@@ -2989,7 +3299,8 @@ class FormatterTest {
       |fun numbers() {
       |  (0 until 100).size
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle while loops`() =
@@ -3000,7 +3311,9 @@ class FormatterTest {
       |    println("Everything is okay")
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle do while loops`() =
@@ -3011,7 +3324,9 @@ class FormatterTest {
       |    println("Everything is okay")
       |  } while (1 < 2)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle break and continue`() =
@@ -3027,7 +3342,9 @@ class FormatterTest {
       |    }
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle all kinds of labels and jumps`() =
@@ -3049,7 +3366,9 @@ class FormatterTest {
       |    return@map 2 * it
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `don't crash on top level statements with semicolons`() {
@@ -3062,7 +3381,8 @@ class FormatterTest {
       |foo { 0 };
       |
       |val fill = 0;
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |val x = { 0 }
@@ -3072,7 +3392,8 @@ class FormatterTest {
       |foo { 0 }
       |
       |val fill = 0
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3089,7 +3410,8 @@ class FormatterTest {
       |
       |  fun isOne(): Boolean = this == ONE
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |enum class SemiColonIsNotRequired {
@@ -3103,7 +3425,8 @@ class FormatterTest {
       |
       |  fun isOne(): Boolean = this == ONE
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3119,7 +3442,8 @@ class FormatterTest {
       |// Don't touch ; inside comments.
       |
       |/** Don't touch ; inside comments. */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |fun f() {
@@ -3130,7 +3454,8 @@ class FormatterTest {
       |// Don't touch ; inside comments.
       |
       |/** Don't touch ; inside comments. */
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3149,7 +3474,8 @@ class FormatterTest {
       |    else
       |  ;
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |fun f() {
@@ -3165,7 +3491,8 @@ class FormatterTest {
       |
       |  if (true)  else ;
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3184,7 +3511,8 @@ class FormatterTest {
       |
       |  foo { trailing -> lambda }; { dead -> lambda }
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |fun f() {
@@ -3206,7 +3534,8 @@ class FormatterTest {
       |  foo { trailing -> lambda };
       |  { dead -> lambda }
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3232,7 +3561,8 @@ class FormatterTest {
       |  }
       |} ;
       |
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |package org.examples
@@ -3258,7 +3588,8 @@ class FormatterTest {
       |    someReallyLongFunctionNameThatMakesThisNotFitInOneLineWithTheAboveVariable()
       |  }
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3285,7 +3616,8 @@ class FormatterTest {
       |fun f() {
       |  a { println("a") }
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle multi statement lambdas`() =
@@ -3297,7 +3629,9 @@ class FormatterTest {
       |    println("b")
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle multi line one statement lambda`() =
@@ -3309,8 +3643,10 @@ class FormatterTest {
       |    println(foo.bar.boom)
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `statements are wrapped in blocks`() =
@@ -3322,7 +3658,9 @@ class FormatterTest {
       |    return
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `properly break fully qualified nested user types`() =
@@ -3337,8 +3675,10 @@ class FormatterTest {
       |                Int, Nothing>,
       |            Nothing>> =
       |    DUMMY
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle multi-line lambdas within lambdas and calling chains`() =
@@ -3367,7 +3707,9 @@ class FormatterTest {
       |        .sum
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle multi line lambdas with explicit args`() =
@@ -3379,8 +3721,10 @@ class FormatterTest {
       |    x + y
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle parenthesis in lambda calls for now`() =
@@ -3389,7 +3733,8 @@ class FormatterTest {
       |fun f() {
       |  a() { println("a") }
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle chaining of calls with lambdas`() =
@@ -3405,7 +3750,9 @@ class FormatterTest {
       |      }
       |      .sum
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle break of lambda args per line with indentation`() =
@@ -3429,8 +3776,10 @@ class FormatterTest {
       |    doIt()
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing comma in lambda`() =
@@ -3447,8 +3796,10 @@ class FormatterTest {
       |    doIt()
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `break before Elvis operator`() =
@@ -3462,8 +3813,10 @@ class FormatterTest {
         |      .find { it.contains(someSearchValue) }
         |      ?: someDefaultValue
         |}
-        |""".trimMargin(),
-          deduceMaxWidth = true)
+        |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle comments in the middle of calling chain`() =
@@ -3478,8 +3831,10 @@ class FormatterTest {
         |      // this is a comment
         |      .doItTwice()
         |}
-        |""".trimMargin(),
-          deduceMaxWidth = true)
+        |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle reified types`() =
@@ -3492,7 +3847,9 @@ class FormatterTest {
       |inline fun <reified in T> foo2(t: T) {
       |  println(t)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle suspended types`() =
@@ -3505,7 +3862,9 @@ class FormatterTest {
       |inline fun <R> foo(noinline block: suspend () -> R): suspend () -> R
       |
       |inline fun <R> bar(noinline block: (suspend () -> R)?): (suspend () -> R)?
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle simple enum classes`() =
@@ -3516,7 +3875,9 @@ class FormatterTest {
       |  FALSE,
       |  FILE_NOT_FOUND,
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle enum class with functions`() =
@@ -3530,7 +3891,9 @@ class FormatterTest {
       |    return true
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle enum with annotations`() =
@@ -3540,7 +3903,9 @@ class FormatterTest {
       |  @True TRUE,
       |  @False @WhatIsTruth FALSE,
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle enum constructor calls`() =
@@ -3550,7 +3915,9 @@ class FormatterTest {
       |  TRUE("true"),
       |  FALSE("false", false),
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle enum entries with body`() =
@@ -3562,7 +3929,9 @@ class FormatterTest {
       |  },
       |  FISH(false) {},
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle empty enum`() =
@@ -3584,7 +3953,8 @@ class FormatterTest {
       |enum class Highlander {
       |  ONE
       |}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `enum comma and semicolon`() {
@@ -3593,13 +3963,17 @@ class FormatterTest {
         |enum class Highlander {
         |  ONE,;
         |}
-        |""".trimMargin())
+        |""".trimMargin(
+        )
+        )
         .isEqualTo(
             """
         |enum class Highlander {
         |  ONE,
         |}
-        |""".trimMargin())
+        |""".trimMargin(
+        )
+        )
   }
 
   @Test
@@ -3613,7 +3987,9 @@ class FormatterTest {
         |
         |  fun f() {}
         |}
-        |""".trimMargin())
+        |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle varargs and spread operator`() =
@@ -3623,7 +3999,9 @@ class FormatterTest {
       |  foo2(*args)
       |  foo3(options = *args)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle typealias`() =
@@ -3636,8 +4014,10 @@ class FormatterTest {
       |typealias PairPair<X, Y> = Pair<Pair<X, Y>, X>
       |
       |class Foo
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle the 'dynamic' type`() =
@@ -3646,7 +4026,9 @@ class FormatterTest {
       |fun x(): dynamic = "x"
       |
       |val dyn: dynamic = 1
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle class expression with generics`() =
@@ -3655,7 +4037,9 @@ class FormatterTest {
       |fun f() {
       |  println(Array<String>::class.java)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `ParseError contains correct line and column numbers`() {
@@ -3667,7 +4051,8 @@ class FormatterTest {
       |}
       |
       |fn (
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     try {
       Formatter.format(code)
       fail()
@@ -3707,7 +4092,9 @@ class FormatterTest {
       |    return (@Fancy 1)
       |  }
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `annotations on function types`() =
@@ -3730,7 +4117,9 @@ class FormatterTest {
       |        (@field:[Inject Named("WEB_VIEW")]
       |        (x) -> Unit)
       |) {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle annotations with use-site targets`() =
@@ -3741,7 +4130,9 @@ class FormatterTest {
       |
       |  @set:Magic(name = "Jane") var field: String
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle annotations mixed with keywords since we cannot reorder them for now`() =
@@ -3752,7 +4143,9 @@ class FormatterTest {
       |public @Magic(1) final class Foo
       |
       |@Magic(1) public final class Foo
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle annotations more`() =
@@ -3771,8 +4164,10 @@ class FormatterTest {
       |  @Annotation // test a comment after annotations
       |  return 5
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `annotated expressions`() =
@@ -3787,7 +4182,9 @@ class FormatterTest {
       |  @Anno4(param = Param2::class)
       |  add(10)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `annotated function declarations`() =
@@ -3802,7 +4199,9 @@ class FormatterTest {
       |fun f() {
       |  add(10)
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `annotated class declarations`() =
@@ -3816,14 +4215,17 @@ class FormatterTest {
       |// Foo
       |@Anno("param")
       |class F
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle type arguments in annotations`() =
       assertFormatted(
           """
       |@TypeParceler<UUID, UUIDParceler>() class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle one line KDoc`() =
@@ -3831,7 +4233,8 @@ class FormatterTest {
           """
       |/** Hi, I am a one line kdoc */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin()
+      )
 
   @Test
   fun `handle KDoc with Link`() =
@@ -3839,7 +4242,9 @@ class FormatterTest {
           """
       |/** This links to [AnotherClass] */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle KDoc with paragraphs`() =
@@ -3851,7 +4256,9 @@ class FormatterTest {
       | * There's a space line to preserve between them
       | */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle KDoc with blocks`() =
@@ -3864,7 +4271,9 @@ class FormatterTest {
       | * @param[param2] this is param2
       | */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle KDoc with code examples`() =
@@ -3886,7 +4295,9 @@ class FormatterTest {
       | * Or after it!
       | */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle KDoc with tagged code examples`() =
@@ -3900,7 +4311,9 @@ class FormatterTest {
       | * ```
       | */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle stray code markers in lines and produce stable output`() {
@@ -3913,7 +4326,8 @@ class FormatterTest {
       | * ```
       | */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertFormatted(Formatter.format(code))
   }
 
@@ -3928,7 +4342,8 @@ class FormatterTest {
       | * ```
       | */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/**
@@ -3938,7 +4353,8 @@ class FormatterTest {
       | * ```
       | */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -3952,7 +4368,8 @@ class FormatterTest {
       | * foo ``` wow
       | */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertFormatted(Formatter.format(code))
   }
 
@@ -3962,7 +4379,9 @@ class FormatterTest {
           """
       |/** Doc line with a reference to [AnotherClass] in the middle of a sentence */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle KDoc with links one after another`() =
@@ -3970,7 +4389,9 @@ class FormatterTest {
           """
       |/** Here are some links [AnotherClass] [AnotherClass2] */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `don't add spaces after links in Kdoc`() =
@@ -3978,7 +4399,9 @@ class FormatterTest {
           """
       |/** Here are some links [AnotherClass][AnotherClass2]hello */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `don't remove spaces after links in Kdoc`() =
@@ -3986,7 +4409,9 @@ class FormatterTest {
           """
       |/** Please see [onNext] (which has more details) */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `link anchor in KDoc are preserved`() =
@@ -3994,7 +4419,9 @@ class FormatterTest {
           """
       |/** [link anchor](the URL for the link anchor goes here) */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `don't add spaces between links in KDoc (because they're actually references)`() =
@@ -4005,7 +4432,9 @@ class FormatterTest {
       |
       |/** The final produced value may have [size][ByteString.size] < [bufferSize]. */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `collapse spaces after links in KDoc`() {
@@ -4013,12 +4442,14 @@ class FormatterTest {
         """
       |/** Here are some links [Class1], [Class2]   [Class3]. hello */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/** Here are some links [Class1], [Class2] [Class3]. hello */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -4031,12 +4462,14 @@ class FormatterTest {
       | * [Class2]
       | */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/** Here are some links [Class1] [Class2] */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -4058,7 +4491,9 @@ class FormatterTest {
       |
       |/** There are many [FooObject]s. */
       |class MyClass {}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `handle KDoc with multiple separated param tags, breaking and merging lines and missing asterisk`() {
@@ -4079,7 +4514,8 @@ class FormatterTest {
       | * @see kotlin.text.isWhitespace
       | */
       |class ThisWasCopiedFromTheTrimMarginMethod {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/**
@@ -4099,7 +4535,8 @@ class FormatterTest {
       | * @see kotlin.text.isWhitespace
       | */
       |class ThisWasCopiedFromTheTrimMarginMethod {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(expected)
   }
 
@@ -4109,7 +4546,8 @@ class FormatterTest {
         """
       |/** Lorem ipsum dolor sit amet, consectetur */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     val expected =
         """
       |/**
@@ -4117,7 +4555,8 @@ class FormatterTest {
       | * consectetur
       | */
       |class MyClass {}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
     assertThatFormatting(code).withOptions(FormattingOptions(maxWidth = 33)).isEqualTo(expected)
   }
 
@@ -4132,7 +4571,8 @@ class FormatterTest {
         |        println(child)
         |    }
         |}
-        |""".trimMargin()
+        |""".trimMargin(
+    )
     assertThatFormatting(code)
         .withOptions(FormattingOptions(maxWidth = 35, blockIndent = 4, continuationIndent = 4))
         .isEqualTo(code)
@@ -4145,7 +4585,9 @@ class FormatterTest {
       |fun doIt() {}
       |
       |/* this is the first comment */
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `preserve LF, CRLF and CR line endings`() {
@@ -4174,8 +4616,10 @@ class FormatterTest {
       |    a: Int,
       |    b: Int
       |)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (explicit constructors)`() =
@@ -4198,8 +4642,10 @@ class FormatterTest {
       |    a: Int,
       |    b: Int
       |)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (secondary constructors)`() =
@@ -4225,8 +4671,10 @@ class FormatterTest {
       |      b: Int
       |  )
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (function definitions)`() =
@@ -4261,8 +4709,10 @@ class FormatterTest {
       |    b: Int,
       |    c: Int,
       |) {}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (function calls)`() =
@@ -4301,8 +4751,10 @@ class FormatterTest {
       |      3,
       |  )
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (proprties)`() =
@@ -4313,8 +4765,10 @@ class FormatterTest {
       |  set(
       |      value,
       |  ) {}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (higher-order functions)`() =
@@ -4327,8 +4781,10 @@ class FormatterTest {
       |            Int,
       |        ) -> Unit
       |) {}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (after lambda arg)`() =
@@ -4338,8 +4794,10 @@ class FormatterTest {
       |fun foo() {
       |  foo({ it },)
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (other)`() =
@@ -4401,8 +4859,10 @@ class FormatterTest {
       |    //
       |  }
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `assignment of a scoping function`() =
@@ -4442,8 +4902,10 @@ class FormatterTest {
       |      foo()
       |      //
       |    }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `top level properties with other types preserve newline spacing`() {
@@ -4479,8 +4941,10 @@ class FormatterTest {
       |val g = 1
       |
       |data class Qux(val foo: String)
-      |""".trimMargin(),
-        deduceMaxWidth = true)
+      |""".trimMargin(
+    ),
+        deduceMaxWidth = true
+    )
 
     assertThatFormatting(
             """
@@ -4488,7 +4952,9 @@ class FormatterTest {
       |import com.example.bar
       |const val SOME_CONST = foo.a
       |val SOME_STR = bar.a
-      |""".trimMargin())
+      |""".trimMargin(
+        )
+        )
         .isEqualTo(
             """
       |import com.example.bar
@@ -4496,7 +4962,9 @@ class FormatterTest {
       |
       |const val SOME_CONST = foo.a
       |val SOME_STR = bar.a
-      |""".trimMargin())
+      |""".trimMargin(
+        )
+        )
   }
 
   @Test
@@ -4535,7 +5003,9 @@ class FormatterTest {
       |
       |
       |val x = Bar()
-      |""".trimMargin())
+      |""".trimMargin(
+          )
+          )
           .isEqualTo(
               """
       |import com.Bar
@@ -4552,7 +5022,9 @@ class FormatterTest {
       |val x = Foo()
       |
       |val x = Bar()
-      |""".trimMargin())
+      |""".trimMargin(
+          )
+          )
 
   @Test
   fun `at least one newline between any adjacent top-level elements, unless it's a property`() =
@@ -4566,7 +5038,9 @@ class FormatterTest {
       |class C {}
       |val x = Foo()
       |val x = Bar()
-      |""".trimMargin())
+      |""".trimMargin(
+          )
+          )
           .isEqualTo(
               """
       |import com.Bar
@@ -4582,7 +5056,9 @@ class FormatterTest {
       |
       |val x = Foo()
       |val x = Bar()
-      |""".trimMargin())
+      |""".trimMargin(
+          )
+          )
 
   @Test
   fun `handle array of annotations with field prefix`() {
@@ -4593,7 +5069,8 @@ class FormatterTest {
     |  var myVar: String? = null
     |}
     |
-    """.trimMargin()
+    """.trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(code)
   }
 
@@ -4606,7 +5083,8 @@ class FormatterTest {
     |  var myVar: String? = null
     |}
     |
-    """.trimMargin()
+    """.trimMargin(
+    )
     assertThatFormatting(code).isEqualTo(code)
   }
 
@@ -4626,7 +5104,8 @@ class FormatterTest {
       |    }
       |  }
       |}
-      |""".trimMargin()
+      |""".trimMargin(
+    )
 
     // Don't throw.
     Formatter.format(code)
@@ -4642,7 +5121,9 @@ class FormatterTest {
       |  val y = 0
       |  y
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `lambda with optional arrow`() =
@@ -4654,7 +5135,9 @@ class FormatterTest {
       |  val y = 0
       |  y
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `lambda missing optional arrow`() =
@@ -4666,7 +5149,9 @@ class FormatterTest {
       |  val y = 0
       |  y
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `chaining - many dereferences`() =
@@ -4684,8 +5169,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, fit on one line`() =
@@ -4693,8 +5180,10 @@ class FormatterTest {
           """
       |---------------------------------------------------------------------------
       |rainbow.red.orange.yellow.green.blue.indigo.violet.cyan.magenta.key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one invocation at end`() =
@@ -4705,8 +5194,10 @@ class FormatterTest {
       |    .green.blue.indigo
       |    .violet.cyan.magenta
       |    .key.build()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one invocation at end, fit on one line`() =
@@ -4714,8 +5205,10 @@ class FormatterTest {
           """
       |---------------------------------------------------------------------------
       |rainbow.red.orange.yellow.green.blue.indigo.violet.cyan.magenta.key.build()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, two invocations at end`() =
@@ -4735,8 +5228,10 @@ class FormatterTest {
       |    .key
       |    .build()
       |    .shine()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one invocation in the middle`() =
@@ -4750,8 +5245,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, two invocations in the middle`() =
@@ -4771,8 +5268,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one lambda at end`() =
@@ -4785,8 +5284,10 @@ class FormatterTest {
       |    .key.build {
       |  it.appear
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one short lambda at end`() =
@@ -4797,8 +5298,10 @@ class FormatterTest {
       |    .green.blue.indigo
       |    .violet.cyan.magenta
       |    .key.z { it }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one multiline lambda at end`() =
@@ -4812,8 +5315,10 @@ class FormatterTest {
       |  it
       |  it
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one short lambda in the middle`() =
@@ -4828,8 +5333,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one multiline lambda in the middle`() =
@@ -4847,8 +5354,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one multiline lambda in the middle, remainder could fit on one line`() =
@@ -4865,8 +5374,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one multiline lambda and two invocations in the middle, remainder could fit on one line`() =
@@ -4890,8 +5401,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one lambda and invocation at end`() =
@@ -4911,8 +5424,10 @@ class FormatterTest {
       |    .key
       |    .z { it }
       |    .shine()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one multiline lambda and invocation at end`() =
@@ -4935,8 +5450,10 @@ class FormatterTest {
       |      it
       |    }
       |    .shine()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one invocation and lambda at end`() =
@@ -4948,8 +5465,10 @@ class FormatterTest {
       |    .violet.cyan.magenta
       |    .key.shine()
       |    .z { it }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, one short lambda and invocation in the middle`() =
@@ -4969,8 +5488,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, invocation and one short lambda in the middle`() =
@@ -4990,8 +5511,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with this`() =
@@ -5008,8 +5531,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with this, one invocation at end`() =
@@ -5020,8 +5545,10 @@ class FormatterTest {
       |    .green.blue.indigo
       |    .violet.cyan.magenta
       |    .key.build()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with super`() =
@@ -5038,8 +5565,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with super, one invocation at end`() =
@@ -5050,8 +5579,10 @@ class FormatterTest {
       |    .green.blue.indigo
       |    .violet.cyan.magenta
       |    .key.build()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with short variable`() =
@@ -5068,8 +5599,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with short variable, one invocation at end`() =
@@ -5080,8 +5613,10 @@ class FormatterTest {
       |    .green.blue.indigo
       |    .violet.cyan.magenta
       |    .key.build()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with short variable and lambda, invocation at end`() =
@@ -5101,8 +5636,10 @@ class FormatterTest {
       |    .magenta
       |    .key
       |    .shine()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting with this and lambda, invocation at end`() =
@@ -5121,8 +5658,10 @@ class FormatterTest {
       |    .magenta
       |    .key
       |    .shine()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many invocations`() =
@@ -5131,7 +5670,8 @@ class FormatterTest {
       |-------------------------
       |rainbow.a().b().c()
       |""".trimMargin(),
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many invocations, with multiline lambda at end`() =
@@ -5142,8 +5682,10 @@ class FormatterTest {
       |  it
       |  it
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many dereferences, starting type name`() =
@@ -5160,8 +5702,10 @@ class FormatterTest {
       |    .cyan
       |    .magenta
       |    .key
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many invocations, starting with short variable, lambda at end`() =
@@ -5171,8 +5715,10 @@ class FormatterTest {
       |z123.shine()
       |    .bright()
       |    .z { it }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - start with invocation, lambda at end`() =
@@ -5182,8 +5728,85 @@ class FormatterTest {
       |getRainbow(
       |        aa, bb, cc)
       |    .z { it }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
+
+  @Test
+  fun `function calls propagrate breaks type args to value args to trailing lambda`() =
+      assertFormatted(
+          """
+      |------------------------------------------
+      |noBreak<AA, BB, CC>(aa, bb, cc) { x = 0 }
+      |
+      |lambdaBreak<AA, BB, CC>(aa, bb, cc) {
+      |  x = 0
+      |}
+      |
+      |lambdaAndValueArgsBreak<AA, BB, CC>(
+      |    aa,
+      |    bb,
+      |    cc
+      |) {
+      |  x = 0
+      |}
+      |
+      |lambdaAndValueArgsAndTypeArgsBreak<
+      |    AA,
+      |    BB,
+      |    CC
+      |>(
+      |    aa,
+      |    bb,
+      |    cc
+      |) {
+      |  x = 0
+      |}
+      |
+      |allTheBreaks_withComments<
+      |    AA,
+      |    BB,
+      |    CC
+      |    //
+      |>(
+      |    aa,
+      |    bb,
+      |    cc
+      |    //
+      |) {
+      |  x = 0
+      |  //
+      |}
+      |
+      |allTheBreaks.inFluentChain.fitsOnOneLine<
+      |    AA,
+      |    BB,
+      |    CC
+      |>(
+      |    aa,
+      |    bb,
+      |    cc
+      |) {
+      |  x = 0
+      |}
+      |
+      |allTheBreaks.inFluentChain
+      |    .withNameSoLongItIsForcedToWrap<
+      |        AA,
+      |        BB,
+      |        CC
+      |    >(
+      |        aa,
+      |        bb,
+      |        cc
+      |    ) {
+      |      x = 0
+      |    }
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - many invocations, start with lambda`() =
@@ -5193,8 +5816,10 @@ class FormatterTest {
       |z { it }
       |    .shine()
       |    .bright()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining - start with type name, end with invocation`() =
@@ -5204,8 +5829,10 @@ class FormatterTest {
       |com.sky.Rainbow
       |    .colorFactory
       |    .build()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda`() =
@@ -5216,8 +5843,10 @@ class FormatterTest {
       |  it
       |  it
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda with trailing dereferences`() =
@@ -5230,8 +5859,10 @@ class FormatterTest {
       |      it
       |    }
       |    .red
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda with long name`() =
@@ -5243,8 +5874,10 @@ class FormatterTest {
       |      it
       |      it
       |    }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda with long name and trailing dereferences`() =
@@ -5257,8 +5890,10 @@ class FormatterTest {
       |      it
       |    }
       |    .red
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda with prefix`() =
@@ -5269,8 +5904,10 @@ class FormatterTest {
       |  it
       |  it
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda with prefix, forced to next line`() =
@@ -5282,8 +5919,10 @@ class FormatterTest {
       |      it
       |      it
       |    }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline lambda with prefix, forced to next line with another expression`() =
@@ -5295,8 +5934,10 @@ class FormatterTest {
       |  it
       |  it
       |}
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments`() =
@@ -5307,8 +5948,10 @@ class FormatterTest {
       |    infrared,
       |    ultraviolet,
       |)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments with trailing dereferences`() =
@@ -5320,8 +5963,10 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .red
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, forced to next line`() =
@@ -5333,8 +5978,10 @@ class FormatterTest {
       |        infrared,
       |        ultraviolet,
       |    )
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, forced to next line with another expression`() =
@@ -5346,8 +5993,10 @@ class FormatterTest {
       |    infrared,
       |    ultraviolet,
       |)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, forced to next line with another expression, with trailing dereferences`() =
@@ -5360,8 +6009,10 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .red
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, with trailing invocation`() =
@@ -5374,8 +6025,10 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .bright()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, with trailing lambda`() =
@@ -5387,8 +6040,10 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .z { it }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, prefixed with super, with trailing invocation`() =
@@ -5400,8 +6055,10 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .bright()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - multiline arguments, starting with short variable, with trailing invocation`() =
@@ -5413,8 +6070,10 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .bright()
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - start with multiline arguments`() =
@@ -5425,8 +6084,10 @@ class FormatterTest {
       |    infrared,
       |    ultraviolet,
       |)
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `chaining (indentation) - start with multiline arguments, with trailing invocation`() =
@@ -5438,6 +6099,8 @@ class FormatterTest {
       |        ultraviolet,
       |    )
       |    .z { it }
-      |""".trimMargin(),
-          deduceMaxWidth = true)
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true
+      )
 }

--- a/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
@@ -54,7 +54,8 @@ class GoogleStyleFormatterKtTest {
         |
         |          ImmutableList.newBuilder().add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).add(1).build()
         |     }
-        |""".trimMargin()
+        |""".trimMargin(
+    )
 
     val expected =
         """
@@ -96,7 +97,8 @@ class GoogleStyleFormatterKtTest {
         |    .add(1)
         |    .build()
         |}
-        |""".trimMargin()
+        |""".trimMargin(
+    )
 
     assertThatFormatting(code).withOptions(Formatter.GOOGLE_FORMAT).isEqualTo(expected)
     // Don't add more tests here
@@ -140,9 +142,11 @@ class GoogleStyleFormatterKtTest {
       |class C(a: Int, var b: Int, val c: Int) {
       |  //
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `function params are placed each in their own line`() =
@@ -188,9 +192,11 @@ class GoogleStyleFormatterKtTest {
       |fun c12(a: Int, var b: Int, val c: Int) {
       |  //
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `return type doesn't fit in one line`() =
@@ -212,9 +218,11 @@ class GoogleStyleFormatterKtTest {
       |    //
       |  }
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `indent parameters after a break when there's a lambda afterwards`() =
@@ -233,9 +241,11 @@ class GoogleStyleFormatterKtTest {
       |      }
       |  }
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `function calls with multiple arguments`() =
@@ -250,8 +260,10 @@ class GoogleStyleFormatterKtTest {
       |    123456789012345678901234567890
       |  )
       |}
-      |""".trimMargin(),
-          formattingOptions = Formatter.GOOGLE_FORMAT)
+      |""".trimMargin(
+      ),
+          formattingOptions = Formatter.GOOGLE_FORMAT
+      )
 
   @Test
   fun `line breaks inside when expressions and conditions`() =
@@ -280,7 +292,8 @@ class GoogleStyleFormatterKtTest {
       |    }
       |    .build()
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
       )
 
@@ -295,7 +308,8 @@ class GoogleStyleFormatterKtTest {
       |    }
       |  )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
       )
 
@@ -312,7 +326,8 @@ class GoogleStyleFormatterKtTest {
       |    }
       |  ) { it.doIt() }
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
       )
 
@@ -327,7 +342,8 @@ class GoogleStyleFormatterKtTest {
       |    }
       |  )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
       )
 
@@ -344,8 +360,10 @@ class GoogleStyleFormatterKtTest {
       |    c = 3456789012345678901234567890
       |  )
       |}
-      |""".trimMargin(),
-          formattingOptions = Formatter.GOOGLE_FORMAT)
+      |""".trimMargin(
+      ),
+          formattingOptions = Formatter.GOOGLE_FORMAT
+      )
 
   @Test
   fun `Arguments are blocks`() =
@@ -372,9 +390,11 @@ class GoogleStyleFormatterKtTest {
       |    )
       |  }
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `keep last expression in qualified indented`() =
@@ -392,9 +412,11 @@ class GoogleStyleFormatterKtTest {
       |        .doThat()
       |    )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `if expression with else`() =
@@ -410,8 +432,10 @@ class GoogleStyleFormatterKtTest {
       |  )
       |  return if (b) 1 else 2
       |}
-      |""".trimMargin(),
-          formattingOptions = Formatter.GOOGLE_FORMAT)
+      |""".trimMargin(
+      ),
+          formattingOptions = Formatter.GOOGLE_FORMAT
+      )
 
   @Test
   fun `named arguments indent their value expression`() =
@@ -426,8 +450,10 @@ class GoogleStyleFormatterKtTest {
       |      },
       |    duration = duration
       |  )
-      |""".trimMargin(),
-          formattingOptions = Formatter.GOOGLE_FORMAT)
+      |""".trimMargin(
+      ),
+          formattingOptions = Formatter.GOOGLE_FORMAT
+      )
 
   @Test
   fun `breaking long binary operations`() =
@@ -449,9 +475,11 @@ class GoogleStyleFormatterKtTest {
       |      ) +
       |      value9
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle casting with breaks`() =
@@ -486,9 +514,11 @@ class GoogleStyleFormatterKtTest {
       |      b is String
       |  )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `line breaks in function arguments`() =
@@ -517,9 +547,11 @@ class GoogleStyleFormatterKtTest {
       |    State(0)
       |  )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   // TODO: there's a bug here - the last case shouldn't break after 'foo'.
   @Test
@@ -546,9 +578,11 @@ class GoogleStyleFormatterKtTest {
       |    )
       |    .doThat()
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a secondary constructor with many arguments passed to delegate`() =
@@ -571,9 +605,11 @@ class GoogleStyleFormatterKtTest {
       |    offspring
       |  )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `a secondary constructor with no arguments passed to delegate`() =
@@ -587,9 +623,11 @@ class GoogleStyleFormatterKtTest {
       |      Foo.createSpeciallyDesignedParameter(),
       |    )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle trailing commas (function calls)`() =
@@ -630,9 +668,11 @@ class GoogleStyleFormatterKtTest {
       |    3,
       |  )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `an assortment of tests for emitQualifiedExpression`() =
@@ -684,9 +724,11 @@ class GoogleStyleFormatterKtTest {
       |    .methodName4()
       |    .abcdefghijkl()
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `keep parenthesis and braces together when there's only one lambda argument`() =
@@ -707,8 +749,10 @@ class GoogleStyleFormatterKtTest {
       |    }
       |  )
       |}
-      |""".trimMargin(),
-          formattingOptions = Formatter.GOOGLE_FORMAT)
+      |""".trimMargin(
+      ),
+          formattingOptions = Formatter.GOOGLE_FORMAT
+      )
 
   @Test
   fun `chained calls that don't fit in one line`() =
@@ -725,9 +769,87 @@ class GoogleStyleFormatterKtTest {
       |      println("b")
       |    )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
+
+  @Test
+  fun `function calls propagrate breaks type args to value args to trailing lambda`() =
+      assertFormatted(
+          """
+      |------------------------------------------
+      |noBreak<AA, BB, CC>(aa, bb, cc) { x = 0 }
+      |
+      |lambdaBreak<AA, BB, CC>(aa, bb, cc) {
+      |  x = 0
+      |}
+      |
+      |lambdaAndValueArgsBreak<AA, BB, CC>(
+      |  aa,
+      |  bb,
+      |  cc
+      |) {
+      |  x = 0
+      |}
+      |
+      |lambdaAndValueArgsAndTypeArgsBreak<
+      |  AA,
+      |  BB,
+      |  CC
+      |>(
+      |  aa,
+      |  bb,
+      |  cc
+      |) {
+      |  x = 0
+      |}
+      |
+      |allTheBreaks_withComments<
+      |  AA,
+      |  BB,
+      |  CC
+      |  //
+      |>(
+      |  aa,
+      |  bb,
+      |  cc
+      |  //
+      |) {
+      |  x = 0
+      |  //
+      |}
+      |
+      |allTheBreaks.inFluentChain.fitsOnOneLine<
+      |  AA,
+      |  BB,
+      |  CC
+      |>(
+      |  aa,
+      |  bb,
+      |  cc
+      |) {
+      |  x = 0
+      |}
+      |
+      |allTheBreaks.inFluentChain
+      |  .withNameSoLongItIsForcedToWrap<
+      |    AA,
+      |    BB,
+      |    CC
+      |  >(
+      |    aa,
+      |    bb,
+      |    cc
+      |  ) {
+      |    x = 0
+      |  }
+      |""".trimMargin(
+      ),
+          deduceMaxWidth = true,
+          formattingOptions = Formatter.GOOGLE_FORMAT
+      )
 
   @Test
   fun `lambda assigned to variable does not break before brace`() =
@@ -744,7 +866,9 @@ class GoogleStyleFormatterKtTest {
       |  doItOnce()
       |  doItTwice()
       |}
-      |""".trimMargin())
+      |""".trimMargin(
+      )
+      )
 
   @Test
   fun `if expression with multiline condition`() =
@@ -768,9 +892,11 @@ class GoogleStyleFormatterKtTest {
       |    bar()
       |  }
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `when() expression with multiline condition`() =
@@ -796,9 +922,11 @@ class GoogleStyleFormatterKtTest {
       |    2 -> print(2)
       |  }
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 
   @Test
   fun `handle destructuring declaration`() =
@@ -818,7 +946,9 @@ class GoogleStyleFormatterKtTest {
       |      boo
       |    )
       |}
-      |""".trimMargin(),
+      |""".trimMargin(
+      ),
           formattingOptions = Formatter.GOOGLE_FORMAT,
-          deduceMaxWidth = true)
+          deduceMaxWidth = true
+      )
 }

--- a/core/src/test/java/com/facebook/ktfmt/testutil/KtfmtTruth.kt
+++ b/core/src/test/java/com/facebook/ktfmt/testutil/KtfmtTruth.kt
@@ -50,14 +50,16 @@ fun assertFormatted(
   if (deduceMaxWidth) {
     if (!isFirstLineAMaxWidthMarker) {
       throw RuntimeException(
-          "deduceMaxWidth is false, please remove the first dashes only line from the code (i.e. ---)")
+          "deduceMaxWidth is false, please remove the first dashes only line from the code (i.e. ---)"
+      )
     }
     deducedCode = code.substring(code.indexOf('\n') + 1)
     maxWidth = first.length
   } else {
     if (isFirstLineAMaxWidthMarker) {
       throw RuntimeException(
-          "When deduceMaxWidth is true the first line need to be all dashes only (i.e. ---)")
+          "When deduceMaxWidth is true the first line need to be all dashes only (i.e. ---)"
+      )
     }
   }
   assertThatFormatting(deducedCode)
@@ -95,7 +97,8 @@ class FormattedCodeSubject(metadata: FailureMetadata, private val code: String) 
               expectedFormatting
                   .lines()
                   .map { if (it.endsWith(" ")) "[$it]" else it }
-                  .joinToString("\n"))
+                  .joinToString("\n")
+      )
     }
     val actualFormatting: String
     try {


### PR DESCRIPTION
There's a bad interaction between this change and the current implementation of fluent chain
formatting, however it should give a feel for the effect. I didn't want to spend too much time
polishing this until we had the general idea worked out. It would probably also be smoother
to rework fluent chains first before working on this change.