### PR TITLE
Always preserve semicolons preceding lambda expressions, even when they might be meaningless

### DIFF
--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -3183,6 +3183,19 @@ class FormatterTest {
       |  foo(0) { trailing -> lambda }; { dead -> lambda }
       |
       |  foo { trailing -> lambda }; { dead -> lambda }
+      |
+      |  val x = foo(); { dead -> lambda }
+      |
+      |  val x = bar() && foo(); { dead -> lambda }
+      |
+      |  // `z` has a property and a method both named `bar`
+      |  val x = z.bar; { dead -> lambda }
+      |
+      |  // `this` has a property and a method both named `bar`
+      |  val x = bar; { dead -> lambda }
+      |
+      |  // Literally any callable expression is dangerous
+      |  val x = (if (cond) x::foo else x::bar); { dead -> lambda }
       |}
       |""".trimMargin()
     val expected =
@@ -3204,6 +3217,24 @@ class FormatterTest {
       |  { dead -> lambda }
       |
       |  foo { trailing -> lambda };
+      |  { dead -> lambda }
+      |
+      |  val x = foo();
+      |  { dead -> lambda }
+      |
+      |  val x = bar() && foo();
+      |  { dead -> lambda }
+      |
+      |  // `z` has a property and a method both named `bar`
+      |  val x = z.bar;
+      |  { dead -> lambda }
+      |
+      |  // `this` has a property and a method both named `bar`
+      |  val x = bar;
+      |  { dead -> lambda }
+      |
+      |  // Literally any callable expression is dangerous
+      |  val x = (if (cond) x::foo else x::bar);
       |  { dead -> lambda }
       |}
       |""".trimMargin()


### PR DESCRIPTION
There are a huge number of cases where removal might change behaviour, because the trailing
lambda syntax is so flexible. Therefore, we just assume that all semicolons followed by
lambdas are meaningful. The cases where they could be removed are too rare to justify the
risk of changing behaviour.

https://github.com/facebookincubator/ktfmt/pull/278 tried to fix this earlier, but missed
a lot of cases. Some examples are added to the tests.