### PR TITLE
Print a single space for empty do-while bodies.

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -2064,8 +2064,10 @@ class KotlinInputAstVisitor(
     builder.sync(expression)
     builder.token("do")
     builder.space()
-    visit(expression.body)
-    builder.space()
+    if (expression.body != null) {
+      visit(expression.body)
+      builder.space()
+    }
     builder.token("while")
     builder.space()
     builder.token("(")

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -3025,6 +3025,8 @@ class FormatterTest {
       |  do {
       |    println("Everything is okay")
       |  } while (1 < 2)
+      |
+      |  do while (1 < 2)
       |}
       |""".trimMargin())
 


### PR DESCRIPTION
Currently two spaces are emitted for empty bodies, because it is assumed a body will always be present.