### PR TITLE
Try to fix issue with MainTest.file is modified if it is not formatted

### DIFF
--- a/core/src/test/java/com/facebook/ktfmt/cli/MainTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/cli/MainTest.kt
@@ -188,6 +188,8 @@ class MainTest {
 
     val lastModifiedTimeBeforeRunningFormatter =
         Files.getLastModifiedTime(unformattedFilePath).toMillis()
+    // The test may run under 1ms, and we need to make sure the new file timestamp will be different
+    Thread.sleep(1)
     Main(emptyInput, PrintStream(out), PrintStream(err), arrayOf(unformattedFile.toString())).run()
     val lastModifiedTimeAfterRunningFormatter =
         Files.getLastModifiedTime(unformattedFilePath).toMillis()

--- a/core/src/test/java/com/facebook/ktfmt/testutil/KtfmtTruth.kt
+++ b/core/src/test/java/com/facebook/ktfmt/testutil/KtfmtTruth.kt
@@ -74,12 +74,11 @@ fun assertThatFormatting(code: String): FormattedCodeSubject {
 
 class FormattedCodeSubject(metadata: FailureMetadata, private val code: String) :
     Subject(metadata, code) {
-  private var options: FormattingOptions =
-      FormattingOptions(debuggingPrintOpsAfterFormatting = true)
+  private var options: FormattingOptions = FormattingOptions()
   private var allowTrailingWhitespace = false
 
   fun withOptions(options: FormattingOptions): FormattedCodeSubject {
-    this.options = options.copy(debuggingPrintOpsAfterFormatting = true)
+    this.options = options
     return this
   }
 
@@ -109,6 +108,9 @@ class FormattedCodeSubject(metadata: FailureMetadata, private val code: String) 
         println("#".repeat(20))
         println(expectedFormatting)
         println("#".repeat(20))
+        println(
+            "Need more information about the break operations?" +
+                "Run test with assertion with \"FormattingOptions(debuggingPrintOpsAfterFormatting = true)\"")
       }
     } catch (e: Error) {
       reportError(code)


### PR DESCRIPTION
Summary:
GitHub actions are failing on this test case:
https://github.com/facebookincubator/ktfmt/runs/6005912425?check_suite_focus=true#step:4:93991

Looks like recent optimizations, and a different order of running stuff can make this test run too fast? I'm not sure, but I'm going to give this a try. If not, I'll run some other debugging ideas for this test.

Differential Revision: D35611158

