### PR TITLE
Fix crashes on intersection types (e.g. Foo<A & B>)

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -31,6 +31,7 @@ import org.jetbrains.kotlin.com.intellij.psi.PsiComment
 import org.jetbrains.kotlin.com.intellij.psi.PsiElement
 import org.jetbrains.kotlin.com.intellij.psi.PsiWhiteSpace
 import org.jetbrains.kotlin.lexer.KtModifierKeywordToken
+import org.jetbrains.kotlin.lexer.KtSingleValueToken
 import org.jetbrains.kotlin.lexer.KtTokens
 import org.jetbrains.kotlin.psi.KtAnnotatedExpression
 import org.jetbrains.kotlin.psi.KtAnnotation
@@ -70,6 +71,7 @@ import org.jetbrains.kotlin.psi.KtFunctionType
 import org.jetbrains.kotlin.psi.KtIfExpression
 import org.jetbrains.kotlin.psi.KtImportDirective
 import org.jetbrains.kotlin.psi.KtImportList
+import org.jetbrains.kotlin.psi.KtIntersectionType
 import org.jetbrains.kotlin.psi.KtIsExpression
 import org.jetbrains.kotlin.psi.KtLabelReferenceExpression
 import org.jetbrains.kotlin.psi.KtLabeledExpression
@@ -229,6 +231,18 @@ class KotlinInputAstVisitor(
     if (typeArgumentList != null) {
       builder.block(expressionBreakIndent) { visit(typeArgumentList) }
     }
+  }
+
+  /** Example: `A & B`, */
+  override fun visitIntersectionType(type: KtIntersectionType) {
+    builder.sync(type)
+
+    // TODO(strulovich): Should this have the same indentation behaviour as `x && y`?
+    visit(type.getLeftTypeRef())
+    builder.space()
+    builder.token("&")
+    builder.space()
+    visit(type.getRightTypeRef())
   }
 
   /** Example `<Int, String>` in `List<Int, String>` */

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -2969,6 +2969,16 @@ class FormatterTest {
       |""".trimMargin())
 
   @Test
+  fun `handle intersection generics`() =
+      assertFormatted(
+          """
+      |fun f() {
+      |  val l: Decl<A & B & C>
+      |  val p = Ctor<A & B & C, T & Y & Z>
+      |}
+      |""".trimMargin())
+
+  @Test
   fun `handle covariant and contravariant type arguments`() =
       assertFormatted("""
       |val p: Pair<in T, out S>


### PR DESCRIPTION
Closes https://github.com/facebookincubator/ktfmt/issues/340