### PR TITLE
Force-break an indent qualified expression rooted on multiline strings

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -467,7 +467,17 @@ class KotlinInputAstVisitor(
           visit(selectorExpression)
         }
       }
-      receiver is KtWhenExpression || receiver is KtStringTemplateExpression -> {
+      receiver is KtStringTemplateExpression -> {
+        builder.block(expressionBreakIndent) {
+          visit(receiver)
+          if (receiver.text.contains('\n')) {
+            builder.forcedBreak()
+          }
+          builder.token(expression.operationSign.value)
+          visit(expression.selectorExpression)
+        }
+      }
+      receiver is KtWhenExpression -> {
         builder.block(ZERO) {
           visit(receiver)
           builder.token(expression.operationSign.value)

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -862,21 +862,28 @@ class FormatterTest {
           deduceMaxWidth = true)
 
   @Test
-  fun `no break between multi-line strings and their selectors`() =
+  fun `forced break between multi-line strings and their selectors`() =
       assertFormatted(
           """
       |-------------------------
       |val STRING =
-      |    ""${'"'}
+      |    $QQQ
       |    |foo
-      |    |""${'"'}.trimMargin()
+      |    |$QQQ
+      |        .wouldFit()
       |
-      |// This is a bug (line is longer than limit)
-      |// that we don't know how to avoid, for now.
       |val STRING =
-      |    ""${'"'}
+      |    $QQQ
       |    |foo
-      |    |----------------------------------""${'"'}.trimMargin()
+      |    |----------------------------------$QQQ
+      |        .wouldntFit()
+      |
+      |val STRING =
+      |    $QQQ
+      |    |foo
+      |    |$QQQ
+      |        .firstLink()
+      |        .secondLink()
       |""".trimMargin(),
           deduceMaxWidth = true)
 
@@ -2459,12 +2466,12 @@ class FormatterTest {
   fun `Consecutive line breaks in multiline strings are preserved`() =
       assertFormatted(
           """
-      |val x = ""${'"'}
+      |val x = $QQQ
       |
       |
       |
       |Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do
-      |""${'"'}
+      |$QQQ
       |""".trimMargin())
 
   @Test
@@ -3527,7 +3534,7 @@ class FormatterTest {
         """
       |fun f() {
       |  val x = ";"
-      |  val x = ""${'"'}  don't touch ; in raw strings ""${'"'}
+      |  val x = $QQQ  don't touch ; in raw strings $QQQ
       |}
       |
       |// Don't touch ; inside comments.
@@ -3538,7 +3545,7 @@ class FormatterTest {
         """
       |fun f() {
       |  val x = ";"
-      |  val x = ""${'"'}  don't touch ; in raw strings ""${'"'}
+      |  val x = $QQQ  don't touch ; in raw strings $QQQ
       |}
       |
       |// Don't touch ; inside comments.
@@ -5979,5 +5986,9 @@ class FormatterTest {
       |""".trimMargin()
 
     assertThatFormatting(code).isEqualTo(expected)
+  }
+
+  companion object {
+    const val QQQ = "\"\"\""
   }
 }

--- a/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
@@ -304,6 +304,33 @@ class GoogleStyleFormatterKtTest {
           deduceMaxWidth = true)
 
   @Test
+  fun `forced break between multi-line strings and their selectors`() =
+      assertFormatted(
+          """
+      |-------------------------
+      |val STRING =
+      |  $QQQ
+      |  |foo
+      |  |$QQQ
+      |    .wouldFit()
+      |
+      |val STRING =
+      |  $QQQ
+      |  |foo
+      |  |----------------------------------$QQQ
+      |    .wouldntFit()
+      |
+      |val STRING =
+      |  $QQQ
+      |  |foo
+      |  |$QQQ
+      |    .firstLink()
+      |    .secondLink()
+      |""".trimMargin(),
+          formattingOptions = Formatter.GOOGLE_FORMAT,
+          deduceMaxWidth = true)
+
+  @Test
   fun `properly break fully qualified nested user types`() =
       assertFormatted(
           """
@@ -1108,4 +1135,8 @@ class GoogleStyleFormatterKtTest {
       |""".trimMargin(),
           formattingOptions = Formatter.GOOGLE_FORMAT,
           deduceMaxWidth = true)
+
+  companion object {
+    const val QQQ = "\"\"\""
+  }
 }


### PR DESCRIPTION
GJF can't track newlines inside individual tokens, which is how multiline
strings are modeled by the lexer. During printing, this creates a disconnect
between the actual line length, and GJF's internal line length tracking.
This disconnect often triggers the next available break-op, even when the
printed code is below the line length limit.

By forcing a break after every multiline string, the inconsistency is removed.
It is particulalry important for --google-style, where the next natural break
is often between the parens of a chained method call, which forces the closing
paren onto its own line.