### PR TITLE
Fix some spacing issues with comma separated lists in --google-style

### DIFF
--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -252,7 +252,7 @@ class KotlinInputAstVisitor(
         typeArgumentList.trailingComma != null,
         prefix = "<",
         postfix = ">",
-        trailingBreak = true,
+        breakBeforePostfix = true,
     )
   }
 
@@ -797,18 +797,18 @@ class KotlinInputAstVisitor(
     val hasTrailingComma = list.trailingComma != null
 
     val wrapInBlock: Boolean
-    val trailingBreak: Boolean
+    val breakBeforePostfix: Boolean
     val leadingBreak: Boolean
     val breakAfterPrefix: Boolean
 
     if (isSingleUnnamedLambda) {
       wrapInBlock = true
-      trailingBreak = false
+      breakBeforePostfix = false
       leadingBreak = arguments.isNotEmpty() && hasTrailingComma
       breakAfterPrefix = false
     } else {
       wrapInBlock = !isGoogleStyle
-      trailingBreak = isGoogleStyle
+      breakBeforePostfix = isGoogleStyle
       leadingBreak = arguments.isNotEmpty()
       breakAfterPrefix = arguments.isNotEmpty()
     }
@@ -817,7 +817,7 @@ class KotlinInputAstVisitor(
         list.arguments,
         hasTrailingComma,
         wrapInBlock = wrapInBlock,
-        trailingBreak = trailingBreak,
+        breakBeforePostfix = breakBeforePostfix,
         leadingBreak = leadingBreak,
         prefix = "(",
         postfix = ")",
@@ -994,13 +994,13 @@ class KotlinInputAstVisitor(
    * @param wrapInBlock if true, place all the elements in a block. When there's no [leadingBreak],
    * this will be negatively indented. Note that the [prefix] and [postfix] aren't included in the
    * block.
-   * @param trailingBreak if true, place a break after the last element. Redundant when
-   * [hasTrailingComma] is true.
    * @param leadingBreak if true, break before the first element.
    * @param prefix if provided, emit this before the first element.
    * @param postfix if provided, emit this after the last element (or trailing comma).
    * @param breakAfterPrefix if true, emit a break after [prefix], but before the start of the
    * block.
+   * @param breakBeforePostfix if true, place a break after the last element. Redundant when
+   * [hasTrailingComma] is true.
    * @return a [BreakTag] which can tell you if a break was taken, but only when the list doesn't
    * terminate in a negative closing indent.
    *
@@ -1036,16 +1036,14 @@ class KotlinInputAstVisitor(
       list: Iterable<PsiElement>,
       hasTrailingComma: Boolean = false,
       wrapInBlock: Boolean = true,
-      trailingBreak: Boolean = isGoogleStyle,
       leadingBreak: Boolean = true,
       prefix: String? = null,
       postfix: String? = null,
       breakAfterPrefix: Boolean = true,
+      breakBeforePostfix: Boolean = isGoogleStyle,
   ): BreakTag? {
-    // a negative closing indent places the postfix to the left of the elements
-    // see examples 2 and 4 in the docstring
-    val needsNegativeClosingIndent = trailingBreak || hasTrailingComma
-    val nameTag = if (needsNegativeClosingIndent) null else genSym()
+    val breakAfterLastElement = hasTrailingComma || (postfix != null && breakBeforePostfix)
+    val nameTag = if (breakAfterLastElement) null else genSym()
 
     if (prefix != null) {
       builder.token(prefix)
@@ -1078,7 +1076,9 @@ class KotlinInputAstVisitor(
       }
     }
 
-    if (needsNegativeClosingIndent) {
+    if (breakAfterLastElement) {
+      // a negative closing indent places the postfix to the left of the elements
+      // see examples 2 and 4 in the docstring
       builder.breakOp(breakType, "", expressionBreakNegativeIndent)
     }
 
@@ -2204,10 +2204,16 @@ class KotlinInputAstVisitor(
       builder.token(".")
     }
     builder.block(expressionBreakIndent) {
-      builder.token("(")
-      visit(type.parameterList)
+      val parameterList = type.parameterList
+      if (parameterList != null) {
+        visitEachCommaSeparated(
+          parameterList.parameters,
+          prefix = "(",
+          postfix = ")",
+          hasTrailingComma = parameterList.trailingComma != null,
+        )
+      }
     }
-    builder.token(")")
     builder.space()
     builder.token("->")
     builder.space()

--- a/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/GoogleStyleFormatterKtTest.kt
@@ -905,6 +905,55 @@ class GoogleStyleFormatterKtTest {
       |""".trimMargin())
 
   @Test
+  fun `comma separated lists, no automatic trailing break after lambda params`() =
+      assertFormatted(
+          """
+      |----------------------------
+      |fun foo() {
+      |  someExpr.let { x -> x }
+      |  someExpr.let { x, y -> x }
+      |
+      |  someExpr.let { paramFits
+      |    ->
+      |    butNotArrow
+      |  }
+      |  someExpr.let { params, fit
+      |    ->
+      |    butNotArrow
+      |  }
+      |
+      |  someExpr.let {
+      |    parameterToLong ->
+      |    fits
+      |  }
+      |  someExpr.let {
+      |    tooLong,
+      |    together ->
+      |    fits
+      |  }
+      |}
+      |""".trimMargin(),
+          formattingOptions = Formatter.GOOGLE_FORMAT,
+          deduceMaxWidth = true)
+
+  @Test
+  fun `comma separated lists, no automatic trailing break after supertype list`() =
+      assertFormatted(
+          """
+      |----------------------------
+      |class Foo() :
+      |  ThisList,
+      |  WillBe,
+      |  TooLong(thats = ok) {
+      |  fun someMethod() {
+      |    val forceBodyBreak = 0
+      |  }
+      |}
+      |""".trimMargin(),
+          formattingOptions = Formatter.GOOGLE_FORMAT,
+          deduceMaxWidth = true)
+
+  @Test
   fun `if expression with multiline condition`() =
       assertFormatted(
           """


### PR DESCRIPTION
After the recent improvments to comma separated list handling, there
are a few cases that suffered collateral damage under --google-style.
This PR is a quick fix to get those cases back to how they used to be,
and add some regression tests. It doesn't necessarily represent the
ideal --gogole-style output.