### PR TITLE
Explicit Kotlin import layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Added
 - Support for `else if` guard conditions (https://github.com/facebook/ktfmt/pull/563)
+- Explicit Kotlin import layout for the default and Google specific editorconfig files to match ktfmt's style. The same layout was already applied to the Kotlin Lang editorconfig (https://github.com/facebook/ktfmt/pull/571) 
 
 
 ## [0.59]

--- a/docs/editorconfig/.editorconfig-default
+++ b/docs/editorconfig/.editorconfig-default
@@ -46,6 +46,7 @@ ij_kotlin_field_annotation_wrap = split_into_lines
 ij_kotlin_finally_on_new_line = false
 ij_kotlin_if_rparen_on_new_line = false
 ij_kotlin_import_nested_classes = false
+ij_kotlin_imports_layout = *
 ij_kotlin_insert_whitespaces_in_simple_one_line_method = true
 ij_kotlin_keep_blank_lines_before_right_brace = 2
 ij_kotlin_keep_blank_lines_in_code = 2

--- a/docs/editorconfig/.editorconfig-google
+++ b/docs/editorconfig/.editorconfig-google
@@ -46,6 +46,7 @@ ij_kotlin_field_annotation_wrap = split_into_lines
 ij_kotlin_finally_on_new_line = false
 ij_kotlin_if_rparen_on_new_line = false
 ij_kotlin_import_nested_classes = false
+ij_kotlin_imports_layout = *
 ij_kotlin_insert_whitespaces_in_simple_one_line_method = true
 ij_kotlin_keep_blank_lines_before_right_brace = 2
 ij_kotlin_keep_blank_lines_in_code = 2


### PR DESCRIPTION
Specify an explicit import layout instead of relying on the Kotlin Official default. The Kotlin Official style uses `ij_kotlin_imports_layout = *,java.**,javax.**,kotlin.**,^`. The new explicit import layout changes it to how ktfmt formats code.

`.editorconfig-kotlinlang` has already applied the same setting.