### PR TITLE
Apply kotlin-test-junit into test classpath

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -36,9 +36,9 @@ dependencies {
   api(libs.guava)
   api(libs.jna)
   api(libs.kotlin.stdlib)
-  api(libs.kotlin.test)
   api(libs.kotlin.compilerEmbeddable)
   implementation(libs.ec4j)
+  testImplementation(libs.kotlin.test.junit4)
   testImplementation(libs.googleTruth)
   testImplementation(libs.junit)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -33,7 +33,7 @@ jna = { module = "net.java.dev.jna:jna", version.ref = "net-java-dev-jna-jna" }
 ktfmt = { module = "com.facebook:ktfmt", version.ref = "ktfmt" }
 kotlin-compilerEmbeddable = { module = "org.jetbrains.kotlin:kotlin-compiler-embeddable", version.ref = "kotlin" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
-kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
+kotlin-test-junit4 = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 
 [plugins]
 dokka = { id = "org.jetbrains.dokka", version.ref = "gradlePlugin-dokka" }


### PR DESCRIPTION
It's not required by the runtime classpath. This also fixes errors like:

```
Execution failed for task ':ktfmt:compileTestKotlin'.
> Could not resolve all files for configuration ':ktfmt:testCompileClasspath'.
   > Could not resolve org.jetbrains.kotlin:kotlin-test:2.2.0.
     Required by:
         project :ktfmt
      > Unable to find a variant with the requested capability: coordinates 'org.jetbrains.kotlin:kotlin-test-framework-junit':
           - Variant 'compile' provides 'org.jetbrains.kotlin:kotlin-test:2.2.0'
           - Variant 'enforced-platform-compile' provides 'org.jetbrains.kotlin:kotlin-test-derived-enforced-platform:2.2.0'
           - Variant 'enforced-platform-runtime' provides 'org.jetbrains.kotlin:kotlin-test-derived-enforced-platform:2.2.0'
           - Variant 'javadoc' provides 'org.jetbrains.kotlin:kotlin-test:2.2.0'
           - Variant 'platform-compile' provides 'org.jetbrains.kotlin:kotlin-test-derived-platform:2.2.0'
           - Variant 'platform-runtime' provides 'org.jetbrains.kotlin:kotlin-test-derived-platform:2.2.0'
           - Variant 'runtime' provides 'org.jetbrains.kotlin:kotlin-test:2.2.0'
           - Variant 'sources' provides 'org.jetbrains.kotlin:kotlin-test:2.2.0'
```