### PR TITLE
Fix IJ Plugin Gradle build

### DIFF
--- a/ktfmt_idea_plugin/build.gradle.kts
+++ b/ktfmt_idea_plugin/build.gradle.kts
@@ -18,9 +18,9 @@ import org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaC
 
 plugins {
   java
-  kotlin("jvm")
-  id("com.ncorti.ktfmt.gradle")
-  id("org.jetbrains.intellij.platform")
+  alias(libs.plugins.kotlin)
+  alias(libs.plugins.ktfmt)
+  alias(libs.plugins.intelliJPlatform)
 }
 
 val ktfmtVersion = rootProject.version


### PR DESCRIPTION
This small PR fixes the IJ Plugin build to use the plugins from the version catalog, ensuring the correct versions are used. This fixes the _Task 'prepareKotlinBuildScriptModel' not found in project ':idea_plugin'._ build/sync error.