### PR TITLE
Support `ij_kotlin_continuation_indent_size` in editorconfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 
 ## [Unreleased]
+### Added
+- Support `ij_kotlin_continuation_indent_size` in editorconfig.
 
 ### Fixed
 - Backtick-escaped full-path imports are no longer incorrectly removed as unused (https://github.com/facebook/ktfmt/issues/532)

--- a/core/src/main/java/com/facebook/ktfmt/cli/EditorConfigResolver.kt
+++ b/core/src/main/java/com/facebook/ktfmt/cli/EditorConfigResolver.kt
@@ -39,6 +39,13 @@ object EditorConfigResolver {
           PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
       )
 
+  private val ijKotlinContinuationIndentSize: PropertyType<Int> =
+      PropertyType.LowerCasingPropertyType(
+          "ij_kotlin_continuation_indent_size",
+          "Denotes the Kotlin-specific continuation indent size. Takes precedence over ij_continuation_indent_size",
+          PropertyType.PropertyValueParser.POSITIVE_INT_VALUE_PARSER,
+      )
+
   private val commaManagementStrategy: PropertyType<TrailingCommaManagementStrategy> =
       PropertyType.LowerCasingPropertyType(
           "ktfmt_trailing_comma_management_strategy",
@@ -61,6 +68,7 @@ object EditorConfigResolver {
             .defaults()
             .type(PropertyType.max_line_length) // missing from defaults?
             .type(ijContinuationIndentSize)
+            .type(ijKotlinContinuationIndentSize)
             .type(commaManagementStrategy)
             .build()
       }
@@ -100,7 +108,8 @@ object EditorConfigResolver {
             ?: getValue(PropertyType.tab_width, baseOptions.blockIndent, false)
 
     val continuationIndent =
-        getValue(ijContinuationIndentSize, baseOptions.continuationIndent, false)
+        properties[ijKotlinContinuationIndentSize.name]?.takeIf { it.isValid }?.getValueAs<Int>()
+            ?: getValue(ijContinuationIndentSize, baseOptions.continuationIndent, false)
 
     val trailingCommaStrategy =
         getValue(commaManagementStrategy, baseOptions.trailingCommaManagementStrategy, false)

--- a/core/src/test/java/com/facebook/ktfmt/cli/EditorConfigResolverTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/cli/EditorConfigResolverTest.kt
@@ -176,6 +176,41 @@ class EditorConfigResolverTest {
   }
 
   @Test
+  fun `overrides continuationIndent based on editorconfig ij_kotlin_continuation_indent_size`() {
+    val conf = root.resolve(".editorconfig")
+    conf.writeText(
+        """
+        root = true
+        [*.kt]
+        ij_kotlin_continuation_indent_size = 3
+        """
+            .trimIndent()
+    )
+
+    val file = root.resolve("src/main/kotlin/Example.kt")
+    val resolved = EditorConfigResolver.resolveFormattingOptions(file, Formatter.GOOGLE_FORMAT)
+    assertThat(resolved).isEqualTo(Formatter.GOOGLE_FORMAT.copy(continuationIndent = 3))
+  }
+
+  @Test
+  fun `ij_kotlin_continuation_indent_size takes precedence over ij_continuation_indent_size`() {
+    val conf = root.resolve(".editorconfig")
+    conf.writeText(
+        """
+        root = true
+        [*.kt]
+        ij_continuation_indent_size = 6
+        ij_kotlin_continuation_indent_size = 3
+        """
+            .trimIndent()
+    )
+
+    val file = root.resolve("src/main/kotlin/Example.kt")
+    val resolved = EditorConfigResolver.resolveFormattingOptions(file, Formatter.GOOGLE_FORMAT)
+    assertThat(resolved).isEqualTo(Formatter.GOOGLE_FORMAT.copy(continuationIndent = 3))
+  }
+
+  @Test
   fun `overrides trailingCommaManagementStrategy based on editorconfig ktfmt_trailing_comma_management_strategy`() {
     val conf = root.resolve(".editorconfig")
     conf.writeText(

--- a/docs/editorconfig/.editorconfig-default
+++ b/docs/editorconfig/.editorconfig-default
@@ -13,6 +13,7 @@ max_line_length = 100
 indent_size = 2
 ij_continuation_indent_size = 4
 ij_java_names_count_to_use_import_on_demand = 9999
+ij_kotlin_continuation_indent_size = 4
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false

--- a/docs/editorconfig/.editorconfig-google
+++ b/docs/editorconfig/.editorconfig-google
@@ -13,6 +13,7 @@ max_line_length = 100
 indent_size = 2
 ij_continuation_indent_size = 2
 ij_java_names_count_to_use_import_on_demand = 9999
+ij_kotlin_continuation_indent_size = 2
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false

--- a/docs/editorconfig/.editorconfig-kotlinlang
+++ b/docs/editorconfig/.editorconfig-kotlinlang
@@ -13,6 +13,7 @@ max_line_length = 100
 indent_size = 4
 ij_continuation_indent_size = 4
 ij_java_names_count_to_use_import_on_demand = 9999
+ij_kotlin_continuation_indent_size = 4
 ij_kotlin_align_in_columns_case_branch = false
 ij_kotlin_align_multiline_binary_operation = false
 ij_kotlin_align_multiline_extends_list = false


### PR DESCRIPTION
ktfmt only recognized the generic `ij_continuation_indent_size` editorconfig property, ignoring the Kotlin-specific `ij_kotlin_continuation_indent_size` that IntelliJ IDEA actually writes for Kotlin files.

## Changes

- **`EditorConfigResolver`**: Add `ij_kotlin_continuation_indent_size` as a recognized property type; resolve it with precedence over `ij_continuation_indent_size`. Uses `Property.isValid()` + `getValueAs()` directly so invalid values fall through to the generic property rather than short-circuiting to the default.
- **Tests**: Cover standalone `ij_kotlin_continuation_indent_size` usage and precedence over `ij_continuation_indent_size`.
- **Example editorconfig files**: Add `ij_kotlin_continuation_indent_size` alongside
`ij_continuation_indent_size` in all bundled style templates.

### Precedence

```
ij_kotlin_continuation_indent_size  (highest — Kotlin-specific)
  ↓ fallback if absent or invalid
ij_continuation_indent_size
  ↓ fallback if absent
baseOptions.continuationIndent
```

---------