### PR TITLE
Remove forced breaking of contextual function types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 ### Added
 - Support `ij_kotlin_indent_size` in editorconfig. (https://github.com/facebook/ktfmt/pull/604)
 - Support for lists within quoted blocks in KDoc comments (https://github.com/facebook/ktfmt/commit/68fa1585b759ad4b12ca4802bccd297f6a33b0f3)
-- Fix `ONLY_ADD` trailing commas strategy causing lines over MAX_WIDTH length (https://github.com/facebook/ktfmt/issues/610) 
+- Fix `ONLY_ADD` trailing commas strategy causing lines over MAX_WIDTH length (https://github.com/facebook/ktfmt/issues/610)
+- Remove forced breaking of `context` function types (https://github.com/facebook/ktfmt/pull/613)
 
 ## [0.62]
 ### Added

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -1820,9 +1820,9 @@ class KotlinInputAstVisitor(
    * Example `context(logger: Logger, raise: Raise<Error>)`
    *
    * Note this also supports the legacy receiver format of `context(Logger, Raise<Error>)` for
-   * backward compatibility.
+   * backward compatibility and for function types
    */
-  override fun visitContextReceiverList(contextReceiverList: KtContextReceiverList) {
+  private fun handleContextReceiverList(contextReceiverList: KtContextReceiverList) {
     builder.sync(contextReceiverList)
     builder.token("context")
     visitEachCommaSeparated(
@@ -1832,6 +1832,10 @@ class KotlinInputAstVisitor(
         breakAfterPrefix = false,
         breakBeforePostfix = false,
     )
+  }
+
+  override fun visitContextReceiverList(contextReceiverList: KtContextReceiverList) {
+    handleContextReceiverList(contextReceiverList)
     builder.forcedBreak()
   }
 
@@ -2465,7 +2469,10 @@ class KotlinInputAstVisitor(
   override fun visitFunctionType(type: KtFunctionType) {
     builder.sync(type)
 
-    type.contextReceiverList?.let { visitContextReceiverList(it) }
+    type.contextReceiverList?.let {
+      handleContextReceiverList(it)
+      builder.space()
+    }
 
     val receiver = type.receiver
     if (receiver != null) {

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -8571,9 +8571,7 @@ class FormatterTest {
         |
         |  fun <T> testSuspend(
         |      mock: T,
-        |      block:
-        |          suspend context(SomeContext)
-        |          T.() -> Unit,
+        |      block: suspend context(SomeContext) T.() -> Unit,
         |  ) = startCoroutine { T.block() }
         |}
         |"""
@@ -8629,9 +8627,7 @@ class FormatterTest {
         |
         |  fun <T> testSuspend(
         |      mock: T,
-        |      block:
-        |          suspend context(someContext: SomeContext)
-        |          T.() -> Unit,
+        |      block: suspend context(someContext: SomeContext) T.() -> Unit,
         |  ) = startCoroutine { T.block() }
         |}
         |"""


### PR DESCRIPTION
Fixes #612 

A rather simple change, ultimately. It seems that the previous behaviour was "intentional", but I think it's rather incorrect. Given that this is an experimental feature, I think changing it now is better than waiting for more complaints.