### PR TITLE
Fix non-idempotent formatting when an auto-inserted trailing comma overflows max_width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
 ### Changed
 
+### Fixed
+
+* Fix non-idempotent formatting when a managed trailing comma pushes a line over MAX_WIDTH (e.g. a long qualified expression as the last argument of a call). The comma is now accounted for by re-running the layout, so the line is broken correctly on the first pass. (https://github.com/facebook/ktfmt/pull/636)
+
 
 ## [0.64]
 

--- a/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
@@ -124,8 +124,7 @@ object Formatter {
               .transform { sortedAndDistinctImports(it) }
               .transform { dropRedundantElements(it, options) }
               .transform { addRedundantElements(it, options) }
-              .transform { prettyPrint(it, options, lineSeparator = "\n") }
-              .transform { addRedundantElements(it, options) }
+              .let { prettyPrintAndManageTrailingCommas(it, options, lineSeparator = "\n") }
               .transform { MultilineStringFormatter(options.continuationIndent).format(it) }
               .code
         } else {
@@ -162,6 +161,21 @@ object Formatter {
     return formattedCode
         .let { convertLineSeparators(it, checkNotNull(Newlines.guessLineSeparator(kotlinCode))) }
         .let { if (shebang.isEmpty()) it else shebang + "\n" + it }
+  }
+
+  /**
+   * Pretty-prints & reprints while [addRedundantElements] keeps adding trailing commas, so a comma
+   * inserted after layout can't leave a line over the limit.
+   */
+  private tailrec fun prettyPrintAndManageTrailingCommas(
+      context: FormatterContext,
+      options: FormattingOptions,
+      lineSeparator: String,
+  ): FormatterContext {
+    val prettyCode = context.transform { prettyPrint(it, options, lineSeparator) }
+    val newCode = prettyCode.transform { addRedundantElements(it, options) }
+    return if (newCode == prettyCode) prettyCode
+    else prettyPrintAndManageTrailingCommas(newCode, options, lineSeparator)
   }
 
   /** prettyPrint reflows 'code' using google-java-format's engine. */

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -9179,6 +9179,41 @@ class FormatterTest {
   }
 
   @Test
+  fun `a trailing comma added while breaking a list does not push the last line over the max width`() {
+    val code =
+        """
+        |functionCall(shortArg, namedArgument = "string sized so the trailing comma ktfmt adds tips it one char over the limit.")
+        |"""
+            .trimMargin()
+
+    val expected =
+        """
+        |functionCall(
+        |    shortArg,
+        |    namedArgument =
+        |        "string sized so the trailing comma ktfmt adds tips it one char over the limit.",
+        |)
+        |"""
+            .trimMargin()
+
+    assertThatFormatting(code).withOptions(Formatter.KOTLINLANG_FORMAT).isEqualTo(expected)
+  }
+
+  @Test
+  fun `formatting a list whose trailing comma lands at the max width is idempotent`() {
+    val code =
+        """
+        |functionCall(shortArg, namedArgument = "string sized so the trailing comma ktfmt adds tips it one char over the limit.")
+        |"""
+            .trimMargin()
+
+    val formattedOnce = Formatter.format(Formatter.KOTLINLANG_FORMAT, code)
+    assertThatFormatting(formattedOnce)
+        .withOptions(Formatter.KOTLINLANG_FORMAT)
+        .isEqualTo(formattedOnce)
+  }
+
+  @Test
   fun `preserve lambda breaks - keeps multi-line lambda multi-line`() {
     val code =
         """


### PR DESCRIPTION
## Summary

Formatting was not idempotent: running ktfmt twice on the same file could produce a different result than running it once.

Trailing commas are inserted as a text edit **after** the line-breaking engine has run. When an argument/parameter list only becomes multi-line **during** layout, the trailing comma that ktfmt then adds was never seen by the engine. If the last element lands exactly on `max_width`, the inserted comma pushes the line to `max_width + 1` — over the limit. On the next run the comma is now real input, so the engine breaks that line differently. Hence the instability.

This builds on #610, which added trailing commas to lists that were *already* multi-line in the source (before layout); this change covers lists that only become multi-line *during* layout.

## Reproduction

Single-line input (the second argument is sized so it sits exactly at the 100-column limit):

```kotlin
functionCall(shortArg, namedArgument = "string sized so the trailing comma ktfmt adds tips it one char over the limit.")
```

`--kotlinlang-style`.

**Before this fix** — pass 1 leaves the argument on one line, one char over the limit, and a
second pass is needed to break it (non-idempotent):

```kotlin
functionCall(
    shortArg,
    namedArgument = "string sized so the trailing comma ktfmt adds tips it one char over the limit.",
)
```

**After** — the value breaks onto its own line in a single pass:

```kotlin
functionCall(
    shortArg,
    namedArgument =
        "string sized so the trailing comma ktfmt adds tips it one char over the limit.",
)
```

Standalone reproducible repo: https://github.com/MathieuLorber/ktfmt-63-non-idempotent-example (initially noticed the problem with 0.63, but still true with 0.64)

## Fix

After the layout pass, re-run the layout while trailing commas keep being added, so the inserted commas are accounted for. Properties:

- No-op extra pass for already-formatted code and when trailing-comma management is disabled (`addRedundantElements` returns the input unchanged, so it stops after a single layout pass).
- Converges, because comma insertion is monotonic (commas are only ever added, and a list with a trailing comma is forced multi-line).

## Tests

Added 2 regression tests (kotlinlang style) for the case above.

## Note for reviewers — implementation style

This PR expresses the fixed-point loop as a `private tailrec fun`. If you'd rather keep the imperative style of the surrounding code, an identical fix using a `while` loop is in branch [`fix-idempotence-after-trailing-comma-with-while`](https://github.com/MathieuLorber/ktfmt/blob/a40b2d0cc8cec4156be75d5f664a187797316ded/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt#L117) — happy to swap to it.
For variable naming and the == comparison I followed FormatterContext's style. 

Thanks !