### PR TITLE
Support val/var keywords in destructuring entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/).
   selected-range formatting flags.
 - Support selected-range formatting in the IntelliJ plugin.
 - GraalVM native image support
+- Support val/var keywords in destructuring entries (https://github.com/facebook/ktfmt/pull/637)
 
 ### Changed
 

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -2431,7 +2431,7 @@ class KotlinInputAstVisitor(
     }
   }
 
-  /** Example `a: String` or `x = a` which is part of `(a: String, x = a)` */
+  /** Example `val a: String` or `x = a` which is part of `(val a: String, x = a)` */
   override fun visitDestructuringDeclarationEntry(
       multiDeclarationEntry: KtDestructuringDeclarationEntry
   ) {
@@ -2442,7 +2442,7 @@ class KotlinInputAstVisitor(
         modifiers = multiDeclarationEntry.modifierList,
         name = multiDeclarationEntry.nameIdentifier?.text ?: fail(),
         type = multiDeclarationEntry.typeReference,
-        valOrVarKeyword = null,
+        valOrVarKeyword = multiDeclarationEntry.ownValOrVarKeyword?.text,
     )
   }
 

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -18,6 +18,7 @@ package com.facebook.ktfmt.format
 
 import com.facebook.ktfmt.util.CONTEXT_PARAMETER_LIST
 import com.facebook.ktfmt.util.listToVisit
+import com.facebook.ktfmt.util.ownValOrVarKeywordText
 import com.google.common.base.Throwables
 import com.google.common.collect.ImmutableList
 import com.google.googlejavaformat.Doc
@@ -2442,7 +2443,7 @@ class KotlinInputAstVisitor(
         modifiers = multiDeclarationEntry.modifierList,
         name = multiDeclarationEntry.nameIdentifier?.text ?: fail(),
         type = multiDeclarationEntry.typeReference,
-        valOrVarKeyword = multiDeclarationEntry.ownValOrVarKeyword?.text,
+        valOrVarKeyword = multiDeclarationEntry.ownValOrVarKeywordText,
     )
   }
 

--- a/core/src/main/java/com/facebook/ktfmt/util/kotlin-2.1/CompatibilityUtils.kt
+++ b/core/src/main/java/com/facebook/ktfmt/util/kotlin-2.1/CompatibilityUtils.kt
@@ -19,6 +19,7 @@
 package com.facebook.ktfmt.util
 
 import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
@@ -27,3 +28,7 @@ fun KtContextReceiverList.listToVisit(): List<KtElement> {
 }
 
 val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_RECEIVER_LIST
+
+/** No val/var keyword in destructuring statements until Kotlin 2.3. */
+val KtDestructuringDeclarationEntry.ownValOrVarKeywordText: String?
+  get() = null

--- a/core/src/main/java/com/facebook/ktfmt/util/kotlin-2.2/CompatibilityUtils.kt
+++ b/core/src/main/java/com/facebook/ktfmt/util/kotlin-2.2/CompatibilityUtils.kt
@@ -19,6 +19,7 @@
 package com.facebook.ktfmt.util
 
 import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
@@ -27,3 +28,7 @@ fun KtContextReceiverList.listToVisit(): List<KtElement> {
 }
 
 val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_RECEIVER_LIST
+
+/** No val/var keyword in destructuring statements until Kotlin 2.3. */
+val KtDestructuringDeclarationEntry.ownValOrVarKeywordText: String?
+  get() = null

--- a/core/src/main/java/com/facebook/ktfmt/util/kotlin-2.3/CompatibilityUtils.kt
+++ b/core/src/main/java/com/facebook/ktfmt/util/kotlin-2.3/CompatibilityUtils.kt
@@ -19,6 +19,7 @@
 package com.facebook.ktfmt.util
 
 import org.jetbrains.kotlin.psi.KtContextReceiverList
+import org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry
 import org.jetbrains.kotlin.psi.KtElement
 import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 
@@ -27,3 +28,6 @@ fun KtContextReceiverList.listToVisit(): List<KtElement> {
 }
 
 val CONTEXT_PARAMETER_LIST = KtStubElementTypes.CONTEXT_PARAMETER_LIST
+
+val KtDestructuringDeclarationEntry.ownValOrVarKeywordText: String?
+  get() = ownValOrVarKeyword?.text

--- a/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/format/FormatterTest.kt
@@ -3082,6 +3082,11 @@ class FormatterTest {
             |fun f(d: D) {
             |  val [a, b         ] = d
             |  val (a, x = b         ) = d
+            |  var [a, _     ] = d
+            |  [var a, var b     ] = d
+            |  [val a: Int, val _: String    ] = d
+            |  (var x = a, var y = b     ) = d
+            |  (val x: Int = a, var y: String = b    ) = d
             |}
             |"""
                 .trimMargin()
@@ -3091,6 +3096,11 @@ class FormatterTest {
             |fun f(d: D) {
             |  val [a, b] = d
             |  val (a, x = b) = d
+            |  var [a, _] = d
+            |  [var a, var b] = d
+            |  [val a: Int, val _: String] = d
+            |  (var x = a, var y = b) = d
+            |  (val x: Int = a, var y: String = b) = d
             |}
             |"""
                 .trimMargin()


### PR DESCRIPTION
Before the change, this code

```kotlin
fun f(d: D) {
  (val a) = d
}

```

raised the error

```
com.google.googlejavaformat.FormattingError: 2:4: error: expected token: 'val'; generated a instead

	at com.google.googlejavaformat.OpsBuilder.token(OpsBuilder.java:342)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.token(KotlinInputAstVisitor.kt:2899)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.token$default(KotlinInputAstVisitor.kt:2898)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.declareOne$lambda$0$0(KotlinInputAstVisitor.kt:1418)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.block(KotlinInputAstVisitor.kt:2924)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.block$default(KotlinInputAstVisitor.kt:2916)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.declareOne$lambda$0(KotlinInputAstVisitor.kt:1400)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.block(KotlinInputAstVisitor.kt:2924)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.block$default(KotlinInputAstVisitor.kt:2916)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.declareOne(KotlinInputAstVisitor.kt:1399)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.declareOne$default(KotlinInputAstVisitor.kt:1376)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.visitDestructuringDeclarationEntry(KotlinInputAstVisitor.kt:2435)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitDestructuringDeclarationEntry(KtVisitorVoid.java:527)
	at org.jetbrains.kotlin.psi.KtVisitorVoid.visitDestructuringDeclarationEntry(KtVisitorVoid.java:10)
	at org.jetbrains.kotlin.psi.KtDestructuringDeclarationEntry.accept(KtDestructuringDeclarationEntry.java:93)
	at org.jetbrains.kotlin.psi.KtElementImpl.accept(KtElementImpl.java:38)
	at com.facebook.ktfmt.format.KotlinInputAstVisitor.visit(KotlinInputAstVisitor.kt:2952)
	at 
[…]
```

Fixes #632
