### PR TITLE
Introduce FormattingOptions.useExperimentalEngine

### DIFF
--- a/core/api/ktfmt.api
+++ b/core/api/ktfmt.api
@@ -129,8 +129,8 @@ public final class com/facebook/ktfmt/format/FormattingOptions {
 	public static final field DEFAULT_CONTINUATION_INDENT I
 	public static final field DEFAULT_MAX_WIDTH I
 	public fun <init> (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZ)V
-	public fun <init> (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZ)V
-	public synthetic fun <init> (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZZ)V
+	public synthetic fun <init> (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (IIIZZZ)V
 	public synthetic fun <init> (IIIZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()I
@@ -140,8 +140,8 @@ public final class com/facebook/ktfmt/format/FormattingOptions {
 	public final fun component5 ()Z
 	public final fun component6 ()Z
 	public final fun component7 ()Z
-	public final fun copy (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZ)Lcom/facebook/ktfmt/format/FormattingOptions;
-	public static synthetic fun copy$default (Lcom/facebook/ktfmt/format/FormattingOptions;IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZILjava/lang/Object;)Lcom/facebook/ktfmt/format/FormattingOptions;
+	public final fun copy (IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZZ)Lcom/facebook/ktfmt/format/FormattingOptions;
+	public static synthetic fun copy$default (Lcom/facebook/ktfmt/format/FormattingOptions;IIILcom/facebook/ktfmt/format/TrailingCommaManagementStrategy;ZZZZILjava/lang/Object;)Lcom/facebook/ktfmt/format/FormattingOptions;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getBlockIndent ()I
 	public final fun getContinuationIndent ()I
@@ -183,7 +183,7 @@ public final class com/facebook/ktfmt/format/KotlinInput : com/google/googlejava
 	public fun getkN ()I
 }
 
-public final class com/facebook/ktfmt/format/KotlinInputAstVisitor : org/jetbrains/kotlin/psi/KtTreeVisitorVoid {
+public class com/facebook/ktfmt/format/KotlinInputAstVisitor : org/jetbrains/kotlin/psi/KtTreeVisitorVoid {
 	public fun <init> (Lcom/facebook/ktfmt/format/FormattingOptions;Lcom/google/googlejavaformat/OpsBuilder;)V
 	public fun visitAnnotatedExpression (Lorg/jetbrains/kotlin/psi/KtAnnotatedExpression;)V
 	public fun visitAnnotation (Lorg/jetbrains/kotlin/psi/KtAnnotation;)V

--- a/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/Formatter.kt
@@ -284,7 +284,11 @@ object Formatter {
     if (KotlinVersion.CURRENT < MINIMUM_KOTLIN_VERSION) {
       throw RuntimeException("Unsupported runtime Kotlin version: " + KotlinVersion.CURRENT)
     }
-    return KotlinInputAstVisitor(options, builder)
+    return if (options.useExperimentalEngine) {
+      KotlinLangInputAstVisitor(options, builder)
+    } else {
+      KotlinInputAstVisitor(options, builder)
+    }
   }
 
   private fun checkEscapeSequences(code: String) {

--- a/core/src/main/java/com/facebook/ktfmt/format/FormattingOptions.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/FormattingOptions.kt
@@ -85,6 +85,9 @@ data class FormattingOptions(
      * newline) decisions
      */
     val debuggingPrintOpsAfterFormatting: Boolean = false,
+
+    // Development only, kotlinlang codestyle experiments
+    private val experimentalEngine: Boolean = false,
 ) {
   companion object {
     const val DEFAULT_MAX_WIDTH: Int = 100
@@ -134,6 +137,9 @@ data class FormattingOptions(
 
   internal val manageTrailingCommas: Boolean
     get() = trailingCommaManagementStrategy != NONE
+
+  internal val useExperimentalEngine: Boolean
+    get() = experimentalEngine
 
   /**
    * Returns a [Builder] pre-populated with this instance's values.

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinInputAstVisitor.kt
@@ -139,10 +139,12 @@ import org.jetbrains.kotlin.psi.stubs.elements.KtStubElementTypes
 import org.jetbrains.kotlin.psi.stubs.impl.KotlinPlaceHolderStubImpl
 
 /** An AST visitor that builds a stream of {@link Op}s to format. */
-class KotlinInputAstVisitor(
+open class KotlinInputAstVisitor(
     private val options: FormattingOptions,
     private val builder: OpsBuilder,
 ) : KtTreeVisitorVoid() {
+
+  internal open val forceAnnotationBreaks: Boolean = false
 
   /** Standard indentation for a block */
   private val blockIndent: Indent.Const = Indent.Const.make(options.blockIndent, 1)
@@ -2144,7 +2146,9 @@ class KotlinInputAstVisitor(
         visit(psi)
       }
 
-      if (onlyAnnotationsSoFar) {
+      if (onlyAnnotationsSoFar && forceAnnotationBreaks && psi is KtAnnotationEntry) {
+        builder.forcedBreak()
+      } else if (onlyAnnotationsSoFar) {
         builder.breakOp(Doc.FillMode.UNIFIED, " ", ZERO)
       } else {
         builder.space()

--- a/core/src/main/java/com/facebook/ktfmt/format/KotlinLangInputAstVisitor.kt
+++ b/core/src/main/java/com/facebook/ktfmt/format/KotlinLangInputAstVisitor.kt
@@ -1,0 +1,10 @@
+package com.facebook.ktfmt.format
+
+import com.google.googlejavaformat.OpsBuilder
+
+internal class KotlinLangInputAstVisitor(
+    options: FormattingOptions,
+    builder: OpsBuilder,
+) : KotlinInputAstVisitor(options, builder) {
+  override val forceAnnotationBreaks: Boolean = true
+}

--- a/core/src/test/java/org/jetbrains/ktfmt/FormatterTestFactory.kt
+++ b/core/src/test/java/org/jetbrains/ktfmt/FormatterTestFactory.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.TestFactory
  * 1) Create a folder with the test group in resources, e.g. "cases/enums/"
  * 2) Populate it with tests: `Foo.input` is an input for the formatter, `Foo.output` is an expected
  *    output. If an .output is not present, it is assumed that formatting `.input` is an idempotent
- *    op
+ *    op. A `Foo.new.output` file additionally runs the case with [NEW_FORMAT]
  * 3) Create a test class in Tests.kt:
  * ```
  * class EnumsTest() : FormatterTestFactory()
@@ -59,8 +59,16 @@ abstract class FormatterTestFactory(
             trailingCommaManagementStrategy = TrailingCommaManagementStrategy.NONE,
         )
 
+    val NEW_FORMAT =
+        Formatter.KOTLINLANG_FORMAT.copy(
+            experimentalEngine = true,
+        )
+
+    // Add other formats if needed for extensibility
+    val FORMAT_VARIANTS = mapOf("new" to NEW_FORMAT)
+
     // Without this, neither 'overwrite' nor navigation in IJ will work
-    val root = run {
+    val ROOT = run {
       val location = javaClass.protectionDomain?.codeSource?.location!!
       val root = URI(location.toURI().toString().substringBefore("build/classes/kotlin/test"))
       Path.of(root).resolve("src/test/resources/cases")
@@ -72,7 +80,7 @@ abstract class FormatterTestFactory(
     // Loads e.g. cases/enums/, all cases from the folder at once
     val cases = load(group)
     check(cases.isNotEmpty()) {
-      "No '.input' files in ${root.resolve(group)}"
+      "No '.input' files in ${ROOT.resolve(group)}"
     }
 
     return cases.map { case ->
@@ -85,7 +93,7 @@ abstract class FormatterTestFactory(
   }
 
   private fun load(group: String): List<TestDescription> {
-    val directory = root.resolve(group)
+    val directory = ROOT.resolve(group)
     require(directory.isDirectory()) { "No such directory: $directory" }
 
     return directory
@@ -106,17 +114,20 @@ abstract class FormatterTestFactory(
   }
 
   private fun tests(expectation: TestCase): List<DynamicTest> {
-    val uri = expectation.description.inputPath.toUri()
+    val uri = (expectation.output ?: expectation.description.inputPath).toUri()
     // format(expected) == actual
     val checks = mutableListOf(
-        DynamicTest.dynamicTest("Formats as expected${expectation.label}", uri) {
+        DynamicTest.dynamicTest(
+            "${expectation.label} Formats as expected",
+            uri,
+        ) {
           formatsAsExpected(expectation)
         },
     )
     // format(format(expected)) == format(expected)
     if (expectation.output != null) {
       checks +=
-          DynamicTest.dynamicTest("Format is idempotent${expectation.label}", uri) {
+          DynamicTest.dynamicTest("${expectation.label} Format is idempotent", uri) {
             outputIsIdempotent(expectation)
           }
     }
@@ -157,8 +168,8 @@ abstract class FormatterTestFactory(
 
   private fun failureMessage(expectation: TestCase, actual: String): String = buildString {
     append(
-        expectation.description.displayName,
         expectation.label,
+        expectation.description.displayName,
         " is not formatted as expected.\n",
     )
     append(
@@ -191,14 +202,27 @@ abstract class FormatterTestFactory(
     val displayName: String
       get() = "$group/$name"
 
-    fun expectations(groupOptions: FormattingOptions): List<TestCase> = listOf(
-        TestCase(
-            description = this,
-            variant = null,
-            output = output,
-            expected = output?.readText(Charsets.UTF_8) ?: input, // No .output, idempotency
-            options = groupOptions,
-        ),
+    fun expectations(groupOptions: FormattingOptions): List<TestCase> = buildList {
+      add(testCase(variant = null, output = output, options = groupOptions))
+
+      FORMAT_VARIANTS.forEach { (variant, options) ->
+        val variantOutput = expectation(variant).takeIf { it.isRegularFile() }
+        if (variantOutput != null) {
+          add(testCase(variant = variant, output = variantOutput, options = options))
+        }
+      }
+    }
+
+    private fun testCase(
+        variant: String?,
+        output: Path?,
+        options: FormattingOptions,
+    ): TestCase = TestCase(
+        description = this,
+        variant = variant,
+        output = output,
+        expected = output?.readText(Charsets.UTF_8) ?: input, // No .output, idempotency
+        options = options,
     )
 
     fun expectation(variant: String?): Path {

--- a/core/src/test/java/org/jetbrains/ktfmt/NewCodeStyleFormatterTest.kt
+++ b/core/src/test/java/org/jetbrains/ktfmt/NewCodeStyleFormatterTest.kt
@@ -1,0 +1,3 @@
+package org.jetbrains.ktfmt
+
+class NewCodeStyleFormatterTest : FormatterTestFactory("new_codestyle")

--- a/core/src/test/resources/cases/new_codestyle/AnnotationsOnSetter.input
+++ b/core/src/test/resources/cases/new_codestyle/AnnotationsOnSetter.input
@@ -1,0 +1,7 @@
+class Holder private constructor(val conf: Configuration) {
+   
+    var someProperty: Boolean = conf.someProperty
+        @Deprecated("Deprecateion message") 
+               @TestOnly 
+    set
+}

--- a/core/src/test/resources/cases/new_codestyle/AnnotationsOnSetter.new.output
+++ b/core/src/test/resources/cases/new_codestyle/AnnotationsOnSetter.new.output
@@ -1,0 +1,7 @@
+class Holder private constructor(val conf: Configuration) {
+
+    var someProperty: Boolean = conf.someProperty
+        @Deprecated("Deprecateion message")
+        @TestOnly
+        set
+}

--- a/core/src/test/resources/cases/new_codestyle/AnnotationsOnSetter.output
+++ b/core/src/test/resources/cases/new_codestyle/AnnotationsOnSetter.output
@@ -1,0 +1,5 @@
+class Holder private constructor(val conf: Configuration) {
+
+  var someProperty: Boolean = conf.someProperty
+    @Deprecated("Deprecateion message") @TestOnly set
+}


### PR DESCRIPTION
* Private, internal-only mode for ongoing development
* A separate KotlinInputAstVisitor to evolve independently, so no actual users are affected
* Add a single test case to showcase the idea

The idea is that we can tweak the independent, publicly non-accessible visitor/format to see if we can comply with various findings from our [comparison](https://htmlpreview.github.io/?https://github.com/qwwdfsad/kotlin-format/blob/master/report.html) by adjusting rules here and there