### PR TITLE
TeamCity CI fixes

### DIFF
--- a/buildSrc/src/main/kotlin/com/facebook/ktfmt/NativeImagePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/facebook/ktfmt/NativeImagePlugin.kt
@@ -62,7 +62,7 @@ class NativeImagePlugin : Plugin<Project> {
     val nativeImageDir = project.layout.projectDirectory.dir(NATIVE_IMAGE_SRC_DIR)
     val javaExtension = project.extensions.getByType<JavaPluginExtension>()
     val nativeImageSourceSet =
-        javaExtension.sourceSets.create("nativeImage") {
+        javaExtension.sourceSets.create("nativeImageSourceSet") {
           java.srcDir(nativeImageDir.dir("java"))
           resources.srcDir(nativeImageDir.dir("resources"))
         }

--- a/core/src/test/java/com/facebook/ktfmt/cli/MainTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/cli/MainTest.kt
@@ -349,7 +349,7 @@ class MainTest {
         .run()
 
     assertThat(out.toString(UTF_8)).doesNotContain("hello, world")
-    assertThat(out.toString(testCharset)).isEqualTo("<stdin>\n")
+    assertThat(out.toString(testCharset)).isEqualTo("<stdin>${System.lineSeparator()}")
   }
 
   @Test
@@ -460,7 +460,7 @@ class MainTest {
         .run()
 
     assertThat(out.toString(UTF_8)).doesNotContain("hello, world")
-    assertThat(out.toString(testCharset)).isEqualTo("<stdin>\n")
+    assertThat(out.toString(testCharset)).isEqualTo("<stdin>${System.lineSeparator()}")
     assertThat(exitCode).isEqualTo(1)
   }
 

--- a/core/src/test/java/com/facebook/ktfmt/cli/ParsedArgsTest.kt
+++ b/core/src/test/java/com/facebook/ktfmt/cli/ParsedArgsTest.kt
@@ -287,7 +287,7 @@ class ParsedArgsTest {
         assertFailsWith<FileNotFoundException> {
           ParsedArgs.processArgs(arrayOf("@non-existing-file"))
         }
-    assertThat(e.message).contains("non-existing-file (No such file or directory)")
+    assertThat(e.message).contains("non-existing-file")
   }
 
   @Test

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Motivation:
* Gradle 8.14 is only compatible with JDKs up to 24, quite a lot of people already use JDK 25+ by default, including our TC agents
* Gradle 9.6.1 is compatible with JDKs 17-26, which matches our build requirements
* Native image plugin change is necessary for Gradle 9.0+ compatibility
* Test changes remove OS-specific elements for compatibility with Windows agents
