### PR TITLE
[github] Don't run "Build and test" action twice on pull requests

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -2,6 +2,8 @@ name: Build and Test
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - '**.md'
   pull_request:


### PR DESCRIPTION
"Build and test" will now only trigger for branches with pull requests **or** pushes to main.

I think we can even remove GitHub Actions in the future, to keep all CI infra in one place. For now I think it makes sense to keep it while we migrate native image tests to TC as well