### PR TITLE
Configure compileClasspath for nativeImageSourceSet

### DIFF
--- a/buildSrc/src/main/kotlin/org/jetbrains/ktfmt/NativeImagePlugin.kt
+++ b/buildSrc/src/main/kotlin/org/jetbrains/ktfmt/NativeImagePlugin.kt
@@ -65,6 +65,7 @@ class NativeImagePlugin : Plugin<Project> {
         javaExtension.sourceSets.create("nativeImageSourceSet") {
           java.srcDir(nativeImageDir.dir("java"))
           resources.srcDir(nativeImageDir.dir("resources"))
+          compileClasspath += nativeImageJavacClasspath
         }
 
     val compileNativeImageClasses =


### PR DESCRIPTION
Sets `nativeImageSourceSet.compileClasspath` to include `nativeImageJavacClasspath` so that IDEA can resolve GraalVM SVM dependencies.

<img width="985" height="438" alt="image" src="https://github.com/user-attachments/assets/2c991a75-6991-4e68-bf55-6801a5f6d2c2" />
